### PR TITLE
#undef the TABLE_NAME and DROP_THIS_TABLE macros at the end of each file...

### DIFF
--- a/src/cff.cc
+++ b/src/cff.cc
@@ -1028,3 +1028,5 @@ void ots_cff_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -1101,3 +1101,5 @@ void ots_cmap_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/cvt.cc
+++ b/src/cvt.cc
@@ -56,3 +56,5 @@ void ots_cvt_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/fpgm.cc
+++ b/src/fpgm.cc
@@ -50,3 +50,5 @@ void ots_fpgm_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/gasp.cc
+++ b/src/gasp.cc
@@ -110,3 +110,6 @@ void ots_gasp_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/gdef.cc
+++ b/src/gdef.cc
@@ -384,3 +384,5 @@ void ots_gdef_free(OpenTypeFile *file) {
 
 }  // namespace ots
 
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/glyf.cc
+++ b/src/glyf.cc
@@ -307,3 +307,5 @@ void ots_glyf_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/gpos.cc
+++ b/src/gpos.cc
@@ -812,3 +812,5 @@ void ots_gpos_free(OpenTypeFile *file) {
 
 }  // namespace ots
 
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/gsub.cc
+++ b/src/gsub.cc
@@ -669,3 +669,5 @@ void ots_gsub_free(OpenTypeFile *file) {
 
 }  // namespace ots
 
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/hdmx.cc
+++ b/src/hdmx.cc
@@ -138,3 +138,6 @@ void ots_hdmx_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/head.cc
+++ b/src/head.cc
@@ -149,3 +149,5 @@ void ots_head_free(OpenTypeFile *file) {
 }
 
 }  // namespace
+
+#undef TABLE_NAME

--- a/src/hhea.cc
+++ b/src/hhea.cc
@@ -49,3 +49,5 @@ void ots_hhea_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/hmtx.cc
+++ b/src/hmtx.cc
@@ -47,3 +47,5 @@ void ots_hmtx_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/kern.cc
+++ b/src/kern.cc
@@ -200,3 +200,6 @@ void ots_kern_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/layout.cc
+++ b/src/layout.cc
@@ -1510,3 +1510,4 @@ bool ParseExtensionSubtable(const OpenTypeFile *file,
 
 }  // namespace ots
 
+#undef TABLE_NAME

--- a/src/loca.cc
+++ b/src/loca.cc
@@ -98,3 +98,5 @@ void ots_loca_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/ltsh.cc
+++ b/src/ltsh.cc
@@ -86,3 +86,6 @@ void ots_ltsh_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/math.cc
+++ b/src/math.cc
@@ -606,3 +606,5 @@ void ots_math_free(OpenTypeFile *file) {
 
 }  // namespace ots
 
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/maxp.cc
+++ b/src/maxp.cc
@@ -128,3 +128,5 @@ void ots_maxp_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -184,3 +184,4 @@ bool SerialiseMetricsTable(const ots::OpenTypeFile *file,
 
 }  // namespace ots
 
+#undef TABLE_NAME

--- a/src/name.cc
+++ b/src/name.cc
@@ -332,3 +332,5 @@ void ots_name_free(OpenTypeFile* file) {
 }
 
 }  // namespace
+
+#undef TABLE_NAME

--- a/src/os2.cc
+++ b/src/os2.cc
@@ -290,3 +290,5 @@ void ots_os2_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/post.cc
+++ b/src/post.cc
@@ -180,3 +180,5 @@ void ots_post_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/prep.cc
+++ b/src/prep.cc
@@ -50,3 +50,5 @@ void ots_prep_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME

--- a/src/vdmx.cc
+++ b/src/vdmx.cc
@@ -181,3 +181,6 @@ void ots_vdmx_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE

--- a/src/vhea.cc
+++ b/src/vhea.cc
@@ -56,3 +56,4 @@ void ots_vhea_free(OpenTypeFile *file) {
 
 }  // namespace ots
 
+#undef TABLE_NAME

--- a/src/vmtx.cc
+++ b/src/vmtx.cc
@@ -52,3 +52,4 @@ void ots_vmtx_free(OpenTypeFile *file) {
 
 }  // namespace ots
 
+#undef TABLE_NAME

--- a/src/vorg.cc
+++ b/src/vorg.cc
@@ -101,3 +101,6 @@ void ots_vorg_free(OpenTypeFile *file) {
 }
 
 }  // namespace ots
+
+#undef TABLE_NAME
+#undef DROP_THIS_TABLE


### PR DESCRIPTION
... that uses them.

This would be helpful for the mozilla build (see https://bugzilla.mozilla.org/show_bug.cgi?id=968139), and is harmless otherwise.
