### PR TITLE
Make the callbacks virtual methods of the OTSContext

### DIFF
--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -179,15 +179,11 @@ class OTSStream {
   unsigned chksum_buffer_offset_;
 };
 
-// Signature of the function to be provided by the client in order to report errors.
-// The return type is a boolean so that it can be used within an expression,
-// but the actual value is ignored. (Suggested convention is to always return 'false'.)
 #ifdef __GCC__
 #define MSGFUNC_FMT_ATTR __attribute__((format(printf, 2, 3)))
 #else
 #define MSGFUNC_FMT_ATTR
 #endif
-typedef bool (*MessageFunc)(void *user_data, const char *format, ...)  MSGFUNC_FMT_ATTR;
 
 enum TableAction {
   TABLE_ACTION_DEFAULT,  // Use OTS's default action for that table
@@ -196,21 +192,9 @@ enum TableAction {
   TABLE_ACTION_DROP      // Drop the table
 };
 
-// Signature of the function to be provided by the client to decide what action
-// to do for a given table.
-//   tag: table tag as an integer in big-endian byte order, independent of platform endianness
-//   user_data: user defined data that are passed to SetTableActionCallback()
-typedef TableAction (*TableActionFunc)(uint32_t tag, void *user_data);
-
 class OTSContext {
   public:
-    OTSContext()
-        : message_func(0),
-          message_user_data(0),
-          table_action_func(0),
-          table_action_user_data(0)
-        {}
-
+    OTSContext() {}
     ~OTSContext() {}
 
     // Process a given OpenType file and write out a sanitised version
@@ -222,24 +206,14 @@ class OTSContext {
     //   context: optional context that holds various OTS settings like user callbacks
     bool Process(OTSStream *output, const uint8_t *input, size_t length);
 
-    // Set a callback function that will be called when OTS is reporting an error.
-    void SetMessageCallback(MessageFunc func, void *user_data) {
-      message_func = func;
-      message_user_data = user_data;
-    }
+    // This function will be called when OTS is reporting an error.
+    virtual void Message(const char *format, ...) MSGFUNC_FMT_ATTR {}
 
-    // Set a callback function that will be called when OTS needs to decide what to
-    // do for a font table.
-    void SetTableActionCallback(TableActionFunc func, void *user_data) {
-      table_action_func = func;
-      table_action_user_data = user_data;
-    }
-
-  private:
-    MessageFunc      message_func;
-    void            *message_user_data;
-    TableActionFunc  table_action_func;
-    void            *table_action_user_data;
+    // This function will be called when OTS needs to decide what to do for a
+    // font table.
+    //   tag: table tag as an integer in big-endian byte order, independent of
+    //   platform endianness
+    virtual TableAction GetTableAction(uint32_t tag) { return ots::TABLE_ACTION_DEFAULT; }
 };
 
 // Force to disable debug output even when the library is compiled with

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -420,9 +420,7 @@ bool ProcessWOFF2(ots::OpenTypeFile *header,
 ots::TableAction GetTableAction(ots::OpenTypeFile *header, uint32_t tag) {
   ots::TableAction action = ots::TABLE_ACTION_DEFAULT;
 
-  if (header->table_action_func != NULL) {
-    action = header->table_action_func(htonl(tag), header->table_action_user_data);
-  }
+  action = header->context->GetTableAction(htonl(tag));
 
   if (action == ots::TABLE_ACTION_DEFAULT) {
     action = ots::TABLE_ACTION_DROP;
@@ -807,10 +805,7 @@ bool OTSContext::Process(OTSStream *output,
                          size_t length) {
   OpenTypeFile header;
 
-  header.message_func = message_func;
-  header.message_user_data = message_user_data;
-  header.table_action_func = table_action_func;
-  header.table_action_user_data = table_action_user_data;
+  header.context = this;
 
   if (length < 4) {
     return OTS_FAILURE_MSG_(&header, "file less than 4 bytes");

--- a/src/ots.h
+++ b/src/ots.h
@@ -52,15 +52,11 @@ void Warning(const char *f, int l, const char *format, ...)
 
 // Generate a simple message
 #define OTS_FAILURE_MSG_(otf_,...) \
-  ((otf_)->message_func && \
-    (*(otf_)->message_func)((otf_)->message_user_data, __VA_ARGS__) && \
-    false)
+  ((otf_)->context->Message(__VA_ARGS__), false)
 
 // Generate a message with an associated table tag
 #define OTS_FAILURE_MSG_TAG_(otf_,msg_,tag_) \
-  ((otf_)->message_func && \
-    (*(otf_)->message_func)((otf_)->message_user_data, "%4.4s: %s", tag_, msg_) && \
-    false)
+  ((otf_)->context->Message("%4.4s: %s", tag_, msg_), false)
 
 // Convenience macro for use in files that only handle a single table tag,
 // defined as TABLE_NAME at the top of the file; the 'file' variable is
@@ -250,11 +246,7 @@ struct OpenTypeFile {
   uint16_t entry_selector;
   uint16_t range_shift;
 
-  MessageFunc  message_func;
-  void        *message_user_data;
-
-  TableActionFunc  table_action_func;
-  void            *table_action_user_data;
+  OTSContext *context;
 
 #define F(name, capname) OpenType##capname *name;
 FOR_EACH_TABLE_TYPE


### PR DESCRIPTION
Instead of the Set\* functions, clients should just override the virtual methods, as suggested by Behdad.

I dropped the user data stuff as I think clients now have more freedom to handle it in more elegant ways.
