### PR TITLE
Fix writing format 13 cmap subtables

### DIFF
--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -1006,8 +1006,8 @@ bool ots_cmap_serialise(OTSStream *out, OpenTypeFile *file) {
         = file->cmap->subtable_3_10_13;
     const unsigned num_groups = groups.size();
     if (!out->WriteU16(13) ||
-        !out->WriteU32(0) ||
-        !out->WriteU32(num_groups * 12 + 14) ||
+        !out->WriteU16(0) ||
+        !out->WriteU32(num_groups * 12 + 16) ||
         !out->WriteU32(0) ||
         !out->WriteU32(num_groups)) {
       return OTS_FAILURE();


### PR DESCRIPTION
The reserved field is only 16 bits, and the length of the header was wrong.  See spec here: http://www.microsoft.com/typography/otspec/cmap.htm.

Does this repo get synced back to the version used by Chromium?  Wondering if I need to submit this patch somewhere else as well.  Thanks!
