### PR TITLE
[cff] Reject non-even args for hinting keys

### DIFF
--- a/src/cff.cc
+++ b/src/cff.cc
@@ -375,12 +375,18 @@ bool ParsePrivateDictData(
     operands.pop_back();
 
     switch (op) {
-      // array
+      // hints
       case 6:  // BlueValues
       case 7:  // OtherBlues
       case 8:  // FamilyBlues
       case 9:  // FamilyOtherBlues
-      case (12U << 8) + 12:  // StemSnapH (delta)
+        if (operands.empty() || ((operands.size() % 2) != 0)) {
+          return OTS_FAILURE();
+        }
+        break;
+
+	  // array
+	  case (12U << 8) + 12:  // StemSnapH (delta)
       case (12U << 8) + 13:  // StemSnapV (delta)
         if (operands.empty()) {
           return OTS_FAILURE();


### PR DESCRIPTION
Non-even numbers of args result in silent failure in at least Chrome & Firefox on Win