### PR TITLE
Make checksum calculation more resilient against stream seek

### DIFF
--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -40,9 +40,7 @@ namespace ots {
 // -----------------------------------------------------------------------------
 class OTSStream {
  public:
-  OTSStream() {
-    ResetChecksum();
-  }
+  OTSStream() : chksum_(0) {}
 
   virtual ~OTSStream() {}
 
@@ -54,20 +52,15 @@ class OTSStream {
 
     const size_t orig_length = length;
     size_t offset = 0;
-    if (chksum_buffer_offset_) {
-      const size_t l =
-        std::min(length, static_cast<size_t>(4) - chksum_buffer_offset_);
-      std::memcpy(chksum_buffer_ + chksum_buffer_offset_, data, l);
-      chksum_buffer_offset_ += l;
-      offset += l;
-      length -= l;
-    }
 
-    if (chksum_buffer_offset_ == 4) {
-      uint32_t tmp;
-      std::memcpy(&tmp, chksum_buffer_, 4);
+    size_t chksum_offset = Tell() & 3;
+    if (chksum_offset) {
+      const size_t l = std::min(length, static_cast<size_t>(4) - chksum_offset);
+      uint32_t tmp = 0;
+      std::memcpy(reinterpret_cast<uint8_t *>(&tmp) + chksum_offset, data, l);
       chksum_ += ntohl(tmp);
-      chksum_buffer_offset_ = 0;
+      length -= l;
+      offset += l;
     }
 
     while (length >= 4) {
@@ -80,11 +73,11 @@ class OTSStream {
     }
 
     if (length) {
-      if (chksum_buffer_offset_ != 0) return false;  // not reached
       if (length > 4) return false;  // not reached
-      std::memcpy(chksum_buffer_,
-             reinterpret_cast<const uint8_t*>(data) + offset, length);
-      chksum_buffer_offset_ = length;
+      uint32_t tmp = 0;
+      std::memcpy(&tmp,
+                  reinterpret_cast<const uint8_t*>(data) + offset, length);
+      chksum_ += ntohl(tmp);
     }
 
     return WriteRaw(data, orig_length);
@@ -145,41 +138,16 @@ class OTSStream {
   }
 
   void ResetChecksum() {
+    assert((Tell() & 3) == 0);
     chksum_ = 0;
-    chksum_buffer_offset_ = 0;
   }
 
   uint32_t chksum() const {
-    assert(chksum_buffer_offset_ == 0);
     return chksum_;
-  }
-
-  struct ChecksumState {
-    uint32_t chksum;
-    uint8_t chksum_buffer[4];
-    unsigned chksum_buffer_offset;
-  };
-
-  ChecksumState SaveChecksumState() const {
-    ChecksumState s;
-    s.chksum = chksum_;
-    s.chksum_buffer_offset = chksum_buffer_offset_;
-    std::memcpy(s.chksum_buffer, chksum_buffer_, 4);
-
-    return s;
-  }
-
-  void RestoreChecksum(const ChecksumState &s) {
-    assert(chksum_buffer_offset_ == 0);
-    chksum_ += s.chksum;
-    chksum_buffer_offset_ = s.chksum_buffer_offset;
-    std::memcpy(chksum_buffer_, s.chksum_buffer, 4);
   }
 
  protected:
   uint32_t chksum_;
-  uint8_t chksum_buffer_[4];
-  unsigned chksum_buffer_offset_;
 };
 
 #ifdef __GCC__

--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -1023,10 +1023,6 @@ bool ots_cmap_serialise(OTSStream *out, OpenTypeFile *file) {
   }
 
   const off_t table_end = out->Tell();
-  // We might have hanging bytes from the above's checksum which the OTSStream
-  // then merges into the table of offsets.
-  OTSStream::ChecksumState saved_checksum = out->SaveChecksumState();
-  out->ResetChecksum();
 
   // Now seek back and write the table of offsets
   if (!out->Seek(record_offset)) {
@@ -1092,7 +1088,6 @@ bool ots_cmap_serialise(OTSStream *out, OpenTypeFile *file) {
   if (!out->Seek(table_end)) {
     return OTS_FAILURE();
   }
-  out->RestoreChecksum(saved_checksum);
 
   return true;
 }


### PR DESCRIPTION
In cmap.cc, ots_cmap_serialise() may seek the output stream to a random
position in the table when it constructs UVS tables. But those seeks
didn't care about checksum calculation state of OTSStream, so it could
lead to an assertion failure in OTSStream::chksum().

After this patch, OTSStream::Write() simply accumulates checksum values
for incomplete words. As a result, it no longer needs to keep hanging
bytes.