### PR TITLE
Add Appveyor CI support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+platform:
+  - x64
+environment:
+  global:
+    MSYS2_BASEVER: 20150512
+  matrix:
+    - MSYS2_ARCH: x86_64
+install:
+  - appveyor DownloadFile "http://kent.dl.sourceforge.net/project/msys2/Base/%MSYS2_ARCH%/msys2-base-%MSYS2_ARCH%-%MSYS2_BASEVER%.tar.xz" -FileName "msys2.tar.xz"
+  - 7z x msys2.tar.xz
+  - 7z x msys2.tar > NUL
+  - msys64\usr\bin\bash -lc ""
+  - msys64\usr\bin\bash -lc "for i in {1..3}; do pacman --noconfirm -Suy autoconf automake pkg-config gcc make zlib-devel && break || sleep 15; done"
+build_script:
+  - msys64\usr\bin\bash -lc "cd $APPVEYOR_BUILD_FOLDER; exec 0</dev/null; ./autogen.sh; ./configure; make"
+# disable automatic tests 
+test: off


### PR DESCRIPTION
There is an ongoing Appveyor CI support add on harfbuzz [here](https://github.com/behdad/harfbuzz/pull/112), don't know for sure but just guessed that can be useful for ots also and it is [working](https://ci.appveyor.com/project/ebraminio/ots/build/1.0.1), maybe we can upload the result somewhere so OTS binary would be easily accessible for average users without lot of hassle.