### PR TITLE
Fix windows build

### DIFF
--- a/src/ots.cc
+++ b/src/ots.cc
@@ -285,7 +285,7 @@ bool ProcessTTC(ots::OpenTypeFile *header,
     return OTS_FAILURE_MSG_HDR("Too many fonts in TTC");
   }
 
-  uint32_t offsets[num_fonts];
+  std::vector<uint32_t> offsets(num_fonts);
   for (unsigned i = 0; i < num_fonts; i++) {
     if (!file.ReadU32(&offsets[i])) {
       return OTS_FAILURE_MSG_HDR("Error reading offset to OffsetTable");


### PR DESCRIPTION
Visual Studio does not support variable length arrays.