### PR TITLE
[ots] restrict max cmap groups in non-default UVS table

### DIFF
--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -517,7 +517,7 @@ bool Parse0514(ots::Font *font,
       if (!subtable.ReadU32(&num_mappings)) {
         return OTS_FAILURE_MSG("Can't read number of mappings in variation selector record %d", i);
       }
-      if (num_mappings == 0) {
+      if (num_mappings == 0 || num_mappings > kMaxCMAPGroups) {
         return OTS_FAILURE_MSG("Bad number of mappings (%d) in variation selector record %d", num_mappings, i);
       }
 


### PR DESCRIPTION
Fixes

````
==9602==ERROR: AddressSanitizer failed to allocate 0x768002000 (31809609728) bytes of LargeMmapAllocator (error code: 12)
==9602==AddressSanitizer CHECK failed: /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_common.cc:180 "((0 && "unable to mmap")) != (0)" (0x0, 0x0)
    #0 0x4b99cd in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/asan_rtl.cc:67
    #1 0x4bfe83 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_common.cc:159
    #2 0x4c006b in __sanitizer::ReportMmapFailureAndDie(unsigned long, char const*, int) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_common.cc:180
    #3 0x4c7deb in __sanitizer::MmapOrDie(unsigned long, char const*) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/sanitizer_common/sanitizer_posix.cc:122
    #4 0x42237a in __sanitizer::LargeMmapAllocator<__asan::AsanMapUnmapCallback>::Allocate(__sanitizer::AllocatorStats*, unsigned long, unsigned long) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_allocator.h:1033
    #5 0x42237a in __sanitizer::CombinedAllocator<__sanitizer::SizeClassAllocator64<105553116266496ul, 4398046511104ul, 0ul, __sanitizer::SizeClassMap<17ul, 128ul, 16ul>, __asan::AsanMapUnmapCallback>, __sanitizer::SizeClassAllocatorLocalCache<__sanitizer::SizeClassAllocator64<105553116266496ul, 4398046511104ul, 0ul, __sanitizer::SizeClassMap<17ul, 128ul, 16ul>, __asan::AsanMapUnmapCallback> >, __sanitizer::LargeMmapAllocator<__asan::AsanMapUnmapCallback> >::Allocate(__sanitizer::SizeClassAllocatorLocalCache<__sanitizer::SizeClassAllocator64<105553116266496ul, 4398046511104ul, 0ul, __sanitizer::SizeClassMap<17ul, 128ul, 16ul>, __asan::AsanMapUnmapCallback> >*, unsigned long, unsigned long, bool, bool) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/../sanitizer_common/sanitizer_allocator.h:1302
    #6 0x42237a in __asan::Allocator::Allocate(unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType, bool) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/asan_allocator.cc:368
    #7 0x42237a in __asan::asan_memalign(unsigned long, unsigned long, __sanitizer::BufferedStackTrace*, __asan::AllocType) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/asan_allocator.cc:705
    #8 0x4df4c8 in operator new(unsigned long) /home/skomski/Code/llvm-related/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:62
    #9 0x52e443 in __gnu_cxx::new_allocator<ots::OpenTypeCMAPSubtableVSMapping>::allocate(unsigned long, void const*) /usr/lib64/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../include/c++/5.2.0/ext/new_allocator.h:104:27
    #10 0x52e443 in __gnu_cxx::__alloc_traits<std::allocator<ots::OpenTypeCMAPSubtableVSMapping> >::allocate(std::allocator<ots::OpenTypeCMAPSubtableVSMapping>&, unsigned long) /usr/lib64/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../include/c++/5.2.0/ext/alloc_traits.h:182
    #11 0x52e443 in std::_Vector_base<ots::OpenTypeCMAPSubtableVSMapping, std::allocator<ots::OpenTypeCMAPSubtableVSMapping> >::_M_allocate(unsigned long) /usr/lib64/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../include/c++/5.2.0/bits/stl_vector.h:170
    #12 0x52e443 in std::vector<ots::OpenTypeCMAPSubtableVSMapping, std::allocator<ots::OpenTypeCMAPSubtableVSMapping> >::_M_fill_insert(__gnu_cxx::__normal_iterator<ots::OpenTypeCMAPSubtableVSMapping*, std::vector<ots::OpenTypeCMAPSubtableVSMapping, std::allocator<ots::OpenTypeCMAPSubtableVSMapping> > >, unsigned long, ots::OpenTypeCMAPSubtableVSMapping const&) /usr/lib64/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../include/c++/5.2.0/bits/vector.tcc:491
    #13 0x5178b4 in std::vector<ots::OpenTypeCMAPSubtableVSMapping, std::allocator<ots::OpenTypeCMAPSubtableVSMapping> >::insert(__gnu_cxx::__normal_iterator<ots::OpenTypeCMAPSubtableVSMapping*, std::vector<ots::OpenTypeCMAPSubtableVSMapping, std::allocator<ots::OpenTypeCMAPSubtableVSMapping> > >, unsigned long, ots::OpenTypeCMAPSubtableVSMapping const&) /usr/lib64/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../include/c++/5.2.0/bits/stl_vector.h:1073:9
    #14 0x5178b4 in std::vector<ots::OpenTypeCMAPSubtableVSMapping, std::allocator<ots::OpenTypeCMAPSubtableVSMapping> >::resize(unsigned long, ots::OpenTypeCMAPSubtableVSMapping) /usr/lib64/gcc/x86_64-unknown-linux-gnu/5.2.0/../../../../include/c++/5.2.0/bits/stl_vector.h:716
    #15 0x5178b4 in (anonymous namespace)::Parse0514(ots::Font*, unsigned char const*, unsigned long, unsigned short) /home/skomski/Code/ots/src/cmap.cc:527
    #16 0x5178b4 in ots::ots_cmap_parse(ots::Font*, unsigned char const*, unsigned long) /home/skomski/Code/ots/src/cmap.cc:801
    #17 0x5da8d7 in (anonymous namespace)::ProcessGeneric(ots::OpenTypeFile*, ots::Font*, unsigned int, ots::OTSStream*, unsigned char const*, unsigned long, std::vector<(anonymous namespace)::OpenTypeTable, std::allocator<(anonymous namespace)::OpenTypeTable> > const&, ots::Buffer&) /home/skomski/Code/ots/src/ots.cc:660:12
    #18 0x5d67e6 in (anonymous namespace)::ProcessTTF(ots::OpenTypeFile*, ots::Font*, ots::OTSStream*, unsigned char const*, unsigned long, unsigned int) /home/skomski/Code/ots/src/ots.cc:220:10
    #19 0x5cd710 in ots::OTSContext::Process(ots::OTSStream*, unsigned char const*, unsigned long, unsigned int) /home/skomski/Code/ots/src/ots.cc:892:14
````