### PR TITLE
Update overflow checks in src/cmap.cc

### DIFF
--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -282,10 +282,7 @@ bool Parse31012(ots::Font *font,
   if (!subtable.ReadU32(&num_groups)) {
     return OTS_FAILURE_MSG("can't read number of format 12 subtable groups");
   }
-  uint32_t groups_size = num_groups * 12;
-  if (num_groups == 0 ||
-      groups_size < num_groups ||
-      subtable.remaining() < groups_size) {
+  if (num_groups == 0 || subtable.remaining() / 12 < num_groups) {
     return OTS_FAILURE_MSG("Bad format 12 subtable group count %d", num_groups);
   }
 
@@ -359,10 +356,7 @@ bool Parse31013(ots::Font *font,
 
   // We limit the number of groups in the same way as in 3.10.12 tables. See
   // the comment there in
-  uint32_t groups_size = num_groups * 12;
-  if (num_groups == 0 ||
-      groups_size < num_groups ||
-      subtable.remaining() < groups_size) {
+  if (num_groups == 0 || subtable.remaining() / 12 < num_groups) {
     return OTS_FAILURE_MSG("Bad format 13 subtable group count %d", num_groups);
   }
 
@@ -470,10 +464,7 @@ bool Parse0514(ots::Font *font,
       if (!subtable.ReadU32(&num_ranges)) {
         return OTS_FAILURE_MSG("Can't read number of ranges in record %d", i);
       }
-      uint32_t ranges_size = num_ranges * 4;
-      if (num_ranges == 0 ||
-          ranges_size < num_ranges ||
-          subtable.remaining() < ranges_size) {
+      if (num_ranges == 0 || subtable.remaining() / 4 < num_ranges) {
         return OTS_FAILURE_MSG("Bad number of ranges (%d) in record %d", num_ranges, i);
       }
 
@@ -507,10 +498,7 @@ bool Parse0514(ots::Font *font,
       if (!subtable.ReadU32(&num_mappings)) {
         return OTS_FAILURE_MSG("Can't read number of mappings in variation selector record %d", i);
       }
-      uint32_t mappings_size = num_mappings * 5;
-      if (num_mappings == 0 ||
-          mappings_size < num_mappings ||
-          subtable.remaining() < mappings_size) {
+      if (num_mappings == 0 || subtable.remaining() / 5 < num_mappings) {
         return OTS_FAILURE_MSG("Bad number of mappings (%d) in variation selector record %d", num_mappings, i);
       }
 


### PR DESCRIPTION
Since mutiplying numbers cannot detect all overflows.