### PR TITLE
Do not reject a sbix font without loca/glyf tables.

### DIFF
--- a/src/ots.cc
+++ b/src/ots.cc
@@ -689,8 +689,9 @@ bool ProcessGeneric(ots::OpenTypeFile *header,
                               GetTableAction(header, tag_) == ots::TABLE_ACTION_PASSTHRU)
       // We don't sanitise bitmap table, but don't reject bitmap-only fonts if
       // we keep the tables.
-      if (!PASSTHRU_TABLE(OTS_TAG('C','B','D','T')) ||
-          !PASSTHRU_TABLE(OTS_TAG('C','B','L','C'))) {
+      if ((!PASSTHRU_TABLE(OTS_TAG('C','B','D','T')) ||
+           !PASSTHRU_TABLE(OTS_TAG('C','B','L','C'))) &&
+          !PASSTHRU_TABLE(OTS_TAG('s','b','i','x'))) {
         return OTS_FAILURE_MSG_HDR("no supported glyph shapes table(s) present");
       }
 #undef PASSTHRU_TABLE


### PR DESCRIPTION
This is for issue #108. 

See also http://crbug.com/605334 and https://codereview.chromium.org/1911123002