### PR TITLE
Eliminate dynamic_cast so OTS can be built with -fno-rtti

### DIFF
--- a/src/cff.cc
+++ b/src/cff.cc
@@ -972,8 +972,8 @@ bool OpenTypeCFF::Parse(const uint8_t *data, size_t length) {
     return OTS_FAILURE();
   }
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+    GetFont()->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("Required maxp table missing");
   }

--- a/src/cff.h
+++ b/src/cff.h
@@ -25,7 +25,7 @@ struct CFFIndex {
 class OpenTypeCFF : public Table {
  public:
   explicit OpenTypeCFF(Font *font, uint32_t tag)
-      : Table(font, tag),
+      : Table(font, tag, OTS_TAG_CFF),
         font_dict_length(0),
         local_subrs(NULL),
         m_data(NULL),

--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -67,8 +67,8 @@ bool OpenTypeCMAP::ParseFormat4(int platform, int encoding,
   // whole thing and recompacting it, we validate it and include it verbatim
   // in the output.
 
-  OpenTypeOS2 *os2 = dynamic_cast<OpenTypeOS2*>(
-      GetFont()->GetTable(OTS_TAG_OS2));
+  OpenTypeOS2 *os2 = static_cast<OpenTypeOS2*>(
+      GetFont()->GetTypedTable(OTS_TAG_OS2));
   if (!os2) {
     return Error("Required OS/2 table missing");
   }
@@ -718,8 +718,8 @@ bool OpenTypeCMAP::Parse(const uint8_t *data, size_t length) {
 
   // we grab the number of glyphs in the file from the maxp table to make sure
   // that the character map isn't referencing anything beyound this range.
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("No maxp table in font! Needed by cmap.");
   }

--- a/src/cmap.h
+++ b/src/cmap.h
@@ -38,7 +38,7 @@ struct OpenTypeCMAPSubtableVSRecord {
 class OpenTypeCMAP : public Table {
  public:
   explicit OpenTypeCMAP(Font *font, uint32_t tag)
-      : Table(font, tag),
+      : Table(font, tag, OTS_TAG_CMAP),
         subtable_0_3_4_data(NULL),
         subtable_0_3_4_length(0),
         subtable_0_5_14_length(0),

--- a/src/cvt.h
+++ b/src/cvt.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeCVT : public Table {
  public:
   explicit OpenTypeCVT(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_CVT) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/fpgm.h
+++ b/src/fpgm.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeFPGM : public Table {
  public:
   explicit OpenTypeFPGM(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_FPGM) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/gasp.h
+++ b/src/gasp.h
@@ -16,7 +16,7 @@ namespace ots {
 class OpenTypeGASP : public Table {
  public:
   explicit OpenTypeGASP(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_GASP) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/gdef.cc
+++ b/src/gdef.cc
@@ -216,8 +216,8 @@ bool OpenTypeGDEF::ParseMarkGlyphSetsDefTable(const uint8_t *data, size_t length
 }
 
 bool OpenTypeGDEF::Parse(const uint8_t *data, size_t length) {
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
 
   // Grab the number of glyphs in the font from the maxp table to check
   // GlyphIDs in GDEF table.

--- a/src/gdef.h
+++ b/src/gdef.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeGDEF : public Table {
  public:
   explicit OpenTypeGDEF(Font *font, uint32_t tag)
-      : Table(font, tag),
+      : Table(font, tag, OTS_TAG_GDEF),
         version_2(false),
         has_glyph_class_def(false),
         has_mark_attachment_class_def(false),

--- a/src/glyf.cc
+++ b/src/glyf.cc
@@ -208,12 +208,12 @@ bool OpenTypeGLYF::ParseCompositeGlyph(Buffer &glyph) {
 }
 
 bool OpenTypeGLYF::Parse(const uint8_t *data, size_t length) {
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
-  OpenTypeLOCA *loca = dynamic_cast<OpenTypeLOCA*>(
-      GetFont()->GetTable(OTS_TAG_LOCA));
-  OpenTypeHEAD *head = dynamic_cast<OpenTypeHEAD*>(
-      GetFont()->GetTable(OTS_TAG_HEAD));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
+  OpenTypeLOCA *loca = static_cast<OpenTypeLOCA*>(
+      GetFont()->GetTypedTable(OTS_TAG_LOCA));
+  OpenTypeHEAD *head = static_cast<OpenTypeHEAD*>(
+      GetFont()->GetTypedTable(OTS_TAG_HEAD));
   if (!maxp || !loca || !head) {
     return Error("Missing maxp or loca or head table needed by glyf table");
   }

--- a/src/glyf.h
+++ b/src/glyf.h
@@ -17,7 +17,7 @@ class OpenTypeMAXP;
 class OpenTypeGLYF : public Table {
  public:
   explicit OpenTypeGLYF(Font *font, uint32_t tag)
-      : Table(font, tag), maxp(NULL) { }
+      : Table(font, tag, OTS_TAG_GLYF), maxp(NULL) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/gpos.cc
+++ b/src/gpos.cc
@@ -221,8 +221,8 @@ bool ParseSingleAdjustment(const ots::Font *font, const uint8_t *data,
                            const size_t length) {
   ots::Buffer subtable(data, length);
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -411,8 +411,8 @@ bool ParsePairAdjustment(const ots::Font *font, const uint8_t *data,
                          const size_t length) {
   ots::Buffer subtable(data, length);
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -460,8 +460,8 @@ bool ParseCursiveAttachment(const ots::Font *font, const uint8_t *data,
                             const size_t length) {
   ots::Buffer subtable(data, length);
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -594,8 +594,8 @@ bool ParseMarkToAttachmentSubtables(const ots::Font *font,
                                     const GPOS_TYPE type) {
   ots::Buffer subtable(data, length);
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -700,13 +700,13 @@ bool ParseMarkToMarkAttachment(const ots::Font *font,
 // Contextual Positioning Subtables
 bool ParseContextPositioning(const ots::Font *font,
                              const uint8_t *data, const size_t length) {
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
-  ots::OpenTypeGPOS *gpos = dynamic_cast<ots::OpenTypeGPOS*>(
-      font->GetTable(OTS_TAG_GPOS));
+  ots::OpenTypeGPOS *gpos = static_cast<ots::OpenTypeGPOS*>(
+      font->GetTypedTable(OTS_TAG_GPOS));
   if (!gpos) {
     return OTS_FAILURE_MSG("Internal error!");
   }
@@ -718,13 +718,13 @@ bool ParseContextPositioning(const ots::Font *font,
 // Chaining Contexual Positioning Subtable
 bool ParseChainedContextPositioning(const ots::Font *font,
                                     const uint8_t *data, const size_t length) {
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
-  ots::OpenTypeGPOS *gpos = dynamic_cast<ots::OpenTypeGPOS*>(
-      font->GetTable(OTS_TAG_GPOS));
+  ots::OpenTypeGPOS *gpos = static_cast<ots::OpenTypeGPOS*>(
+      font->GetTypedTable(OTS_TAG_GPOS));
   if (!gpos) {
     return OTS_FAILURE_MSG("Internal error!");
   }

--- a/src/gpos.h
+++ b/src/gpos.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeGPOS : public Table {
  public:
   explicit OpenTypeGPOS(Font *font, uint32_t tag)
-      : Table(font, tag),
+      : Table(font, tag, OTS_TAG_GPOS),
         num_lookups(0),
         m_data(NULL),
         m_length(0) {

--- a/src/gsub.cc
+++ b/src/gsub.cc
@@ -82,8 +82,8 @@ bool ParseSingleSubstitution(const ots::Font *font,
     return OTS_FAILURE_MSG("Failed to read single subst table header");
   }
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -175,8 +175,8 @@ bool ParseMutipleSubstitution(const ots::Font *font,
     return OTS_FAILURE_MSG("Bad multiple subst table format %d", format);
   }
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -255,8 +255,8 @@ bool ParseAlternateSubstitution(const ots::Font *font,
     return OTS_FAILURE_MSG("Bad alternate subst table format %d", format);
   }
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -377,8 +377,8 @@ bool ParseLigatureSubstitution(const ots::Font *font,
     return OTS_FAILURE_MSG("Bad ligature substitution table format %d", format);
   }
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
@@ -418,13 +418,13 @@ bool ParseLigatureSubstitution(const ots::Font *font,
 // Contextual Substitution Subtable
 bool ParseContextSubstitution(const ots::Font *font,
                               const uint8_t *data, const size_t length) {
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
-  ots::OpenTypeGSUB *gsub = dynamic_cast<ots::OpenTypeGSUB*>(
-      font->GetTable(OTS_TAG_GSUB));
+  ots::OpenTypeGSUB *gsub = static_cast<ots::OpenTypeGSUB*>(
+      font->GetTypedTable(OTS_TAG_GSUB));
   if (!gsub) {
     return OTS_FAILURE_MSG("Internal error!");
   }
@@ -437,13 +437,13 @@ bool ParseContextSubstitution(const ots::Font *font,
 bool ParseChainingContextSubstitution(const ots::Font *font,
                                       const uint8_t *data,
                                       const size_t length) {
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }
-  ots::OpenTypeGSUB *gsub = dynamic_cast<ots::OpenTypeGSUB*>(
-      font->GetTable(OTS_TAG_GSUB));
+  ots::OpenTypeGSUB *gsub = static_cast<ots::OpenTypeGSUB*>(
+      font->GetTypedTable(OTS_TAG_GSUB));
   if (!gsub) {
     return OTS_FAILURE_MSG("Internal error!");
   }
@@ -474,8 +474,8 @@ bool ParseReverseChainingContextSingleSubstitution(
     return OTS_FAILURE_MSG("Failed to read reverse chaining header");
   }
 
-  ots::OpenTypeMAXP *maxp = dynamic_cast<ots::OpenTypeMAXP*>(
-      font->GetTable(OTS_TAG_MAXP));
+  ots::OpenTypeMAXP *maxp = static_cast<ots::OpenTypeMAXP*>(
+      font->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return OTS_FAILURE_MSG("Required maxp table missing");
   }

--- a/src/gsub.h
+++ b/src/gsub.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeGSUB : public Table {
  public:
   explicit OpenTypeGSUB(Font *font, uint32_t tag)
-      : Table(font, tag),
+      : Table(font, tag, OTS_TAG_GSUB),
         num_lookups(0),
         m_data(NULL),
         m_length(0) {

--- a/src/hdmx.cc
+++ b/src/hdmx.cc
@@ -14,10 +14,10 @@ namespace ots {
 bool OpenTypeHDMX::Parse(const uint8_t *data, size_t length) {
   Buffer table(data, length);
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
-  OpenTypeHEAD *head = dynamic_cast<OpenTypeHEAD*>(
-      GetFont()->GetTable(OTS_TAG_HEAD));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
+  OpenTypeHEAD *head = static_cast<OpenTypeHEAD*>(
+      GetFont()->GetTypedTable(OTS_TAG_HEAD));
   if (!head || !maxp) {
     return Error("Missing maxp or head tables in font, needed by hdmx");
   }

--- a/src/hdmx.h
+++ b/src/hdmx.h
@@ -20,7 +20,7 @@ struct OpenTypeHDMXDeviceRecord {
 class OpenTypeHDMX : public Table {
  public:
   explicit OpenTypeHDMX(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_HDMX) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/head.h
+++ b/src/head.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeHEAD : public Table {
  public:
   explicit OpenTypeHEAD(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_HEAD) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/hhea.h
+++ b/src/hhea.h
@@ -13,7 +13,7 @@ namespace ots {
 class OpenTypeHHEA : public OpenTypeMetricsHeader {
  public:
   explicit OpenTypeHHEA(Font *font, uint32_t tag)
-      : OpenTypeMetricsHeader(font, tag) { }
+      : OpenTypeMetricsHeader(font, tag, OTS_TAG_HHEA) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/hmtx.h
+++ b/src/hmtx.h
@@ -14,7 +14,7 @@ namespace ots {
 class OpenTypeHMTX : public OpenTypeMetricsTable {
  public:
   explicit OpenTypeHMTX(Font *font, uint32_t tag)
-      : OpenTypeMetricsTable(font, tag, OTS_TAG_HHEA) { }
+      : OpenTypeMetricsTable(font, tag, OTS_TAG_HMTX, OTS_TAG_HHEA) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/kern.h
+++ b/src/kern.h
@@ -33,7 +33,7 @@ struct OpenTypeKERNFormat0 {
 class OpenTypeKERN : public Table {
  public:
   explicit OpenTypeKERN(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_KERN) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/layout.cc
+++ b/src/layout.cc
@@ -197,8 +197,8 @@ bool ParseLookupTable(ots::Font *font, const uint8_t *data,
     return OTS_FAILURE_MSG("Bad lookup type %d", lookup_type);
   }
 
-  ots::OpenTypeGDEF *gdef = dynamic_cast<ots::OpenTypeGDEF*>(
-      font->GetTable(OTS_TAG_GDEF));
+  ots::OpenTypeGDEF *gdef = static_cast<ots::OpenTypeGDEF*>(
+      font->GetTypedTable(OTS_TAG_GDEF));
 
   // Check lookup flags.
   if ((lookup_flag & kGdefRequiredFlags) &&

--- a/src/loca.cc
+++ b/src/loca.cc
@@ -18,10 +18,10 @@ bool OpenTypeLOCA::Parse(const uint8_t *data, size_t length) {
   // We can't do anything useful in validating this data except to ensure that
   // the values are monotonically increasing.
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
-  OpenTypeHEAD *head = dynamic_cast<OpenTypeHEAD*>(
-      GetFont()->GetTable(OTS_TAG_HEAD));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
+  OpenTypeHEAD *head = static_cast<OpenTypeHEAD*>(
+      GetFont()->GetTypedTable(OTS_TAG_HEAD));
   if (!maxp || !head) {
     return Error("Required maxp or head tables are missing");
   }
@@ -64,8 +64,8 @@ bool OpenTypeLOCA::Parse(const uint8_t *data, size_t length) {
 }
 
 bool OpenTypeLOCA::Serialize(OTSStream *out) {
-  OpenTypeHEAD *head = dynamic_cast<OpenTypeHEAD*>(
-      GetFont()->GetTable(OTS_TAG_HEAD));
+  OpenTypeHEAD *head = static_cast<OpenTypeHEAD*>(
+      GetFont()->GetTypedTable(OTS_TAG_HEAD));
 
   if (!head) {
     return Error("Required head table is missing");

--- a/src/loca.h
+++ b/src/loca.h
@@ -14,7 +14,7 @@ namespace ots {
 class OpenTypeLOCA : public Table {
  public:
   explicit OpenTypeLOCA(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_LOCA) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/ltsh.cc
+++ b/src/ltsh.cc
@@ -14,8 +14,8 @@ namespace ots {
 bool OpenTypeLTSH::Parse(const uint8_t *data, size_t length) {
   Buffer table(data, length);
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("Required maxp table is missing");
   }

--- a/src/ltsh.h
+++ b/src/ltsh.h
@@ -14,7 +14,7 @@ namespace ots {
 class OpenTypeLTSH : public Table {
  public:
   explicit OpenTypeLTSH(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_LTSH) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/math.cc
+++ b/src/math.cc
@@ -516,8 +516,8 @@ bool OpenTypeMATH::ParseMathVariantsTable(const uint8_t *data,
 bool OpenTypeMATH::Parse(const uint8_t *data, size_t length) {
   // Grab the number of glyphs in the font from the maxp table to check
   // GlyphIDs in MATH table.
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("Required maxp table missing");
   }

--- a/src/math_.h
+++ b/src/math_.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeMATH : public Table {
  public:
   explicit OpenTypeMATH(Font *font, uint32_t tag)
-      : Table(font, tag),
+      : Table(font, tag, OTS_TAG_MATH),
         m_data(NULL),
         m_length(0) { }
 

--- a/src/maxp.h
+++ b/src/maxp.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypeMAXP : public Table {
  public:
   explicit OpenTypeMAXP(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_MAXP) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -43,8 +43,8 @@ bool OpenTypeMetricsHeader::Parse(const uint8_t *data, size_t length) {
     this->linegap = 0;
   }
 
-  OpenTypeHEAD *head = dynamic_cast<OpenTypeHEAD*>(
-      GetFont()->GetTable(OTS_TAG_HEAD));
+  OpenTypeHEAD *head = static_cast<OpenTypeHEAD*>(
+      GetFont()->GetTypedTable(OTS_TAG_HEAD));
   if (!head) {
     return Error("Missing head font table");
   }
@@ -73,8 +73,8 @@ bool OpenTypeMetricsHeader::Parse(const uint8_t *data, size_t length) {
     return Error("Failed to read number of metrics");
   }
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("Missing maxp font table");
   }
@@ -110,8 +110,10 @@ bool OpenTypeMetricsHeader::Serialize(OTSStream *out) {
 bool OpenTypeMetricsTable::Parse(const uint8_t *data, size_t length) {
   Buffer table(data, length);
 
-  OpenTypeMetricsHeader *header = dynamic_cast<OpenTypeMetricsHeader*>(
-      GetFont()->GetTable(m_header_tag));
+  // OpenTypeMetricsHeader is a superclass of both 'hhea' and 'vhea',
+  // so the cast here is OK, whichever m_header_tag we have.
+  OpenTypeMetricsHeader *header = static_cast<OpenTypeMetricsHeader*>(
+      GetFont()->GetTypedTable(m_header_tag));
   if (!header) {
     return Error("Required %c%c%c%c table missing", OTS_UNTAG(m_header_tag));
   }
@@ -119,8 +121,8 @@ bool OpenTypeMetricsTable::Parse(const uint8_t *data, size_t length) {
   // amount of memory that we'll allocate for this to a sane amount.
   const unsigned num_metrics = header->num_metrics;
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP *maxp = static_cast<OpenTypeMAXP*>(
+      GetFont()->GetTypedTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("Required maxp table missing");
   }

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -15,8 +15,8 @@ namespace ots {
 
 class OpenTypeMetricsHeader : public Table {
  public:
-  explicit OpenTypeMetricsHeader(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+  explicit OpenTypeMetricsHeader(Font *font, uint32_t tag, uint32_t type)
+      : Table(font, tag, type) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);
@@ -37,9 +37,9 @@ class OpenTypeMetricsHeader : public Table {
 
 struct OpenTypeMetricsTable : public Table {
  public:
-  explicit OpenTypeMetricsTable(Font *font, uint32_t tag,
+  explicit OpenTypeMetricsTable(Font *font, uint32_t tag, uint32_t type,
                                 uint32_t header_tag)
-      : Table(font, tag), m_header_tag(header_tag) { }
+      : Table(font, tag, type), m_header_tag(header_tag) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/name.h
+++ b/src/name.h
@@ -46,7 +46,7 @@ struct NameRecord {
 class OpenTypeNAME : public Table {
  public:
   explicit OpenTypeNAME(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_NAME) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/os2.cc
+++ b/src/os2.cc
@@ -130,8 +130,8 @@ bool OpenTypeOS2::Parse(const uint8_t *data, size_t length) {
 
   // the settings of bits 0 and 1 must be reflected in the macStyle bits
   // in the 'head' table.
-  OpenTypeHEAD *head = dynamic_cast<OpenTypeHEAD*>(
-      GetFont()->GetTable(OTS_TAG_HEAD));
+  OpenTypeHEAD *head = static_cast<OpenTypeHEAD*>(
+      GetFont()->GetTypedTable(OTS_TAG_HEAD));
 
   if ((this->table.selection & 0x1) &&
       head && !(head->mac_style & 0x2)) {

--- a/src/os2.h
+++ b/src/os2.h
@@ -54,7 +54,7 @@ struct OS2Data {
 class OpenTypeOS2 : public Table {
  public:
   explicit OpenTypeOS2(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_OS2) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -903,6 +903,13 @@ Table* Font::GetTable(uint32_t tag) const {
   return NULL;
 }
 
+Table* Font::GetTypedTable(uint32_t tag) const {
+  Table* t = GetTable(tag);
+  if (t && t->Type() == tag)
+    return t;
+  return NULL;
+}
+
 bool Table::ShouldSerialize() {
   return m_shouldSerialize;
 }

--- a/src/post.cc
+++ b/src/post.cc
@@ -50,8 +50,8 @@ bool OpenTypePOST::Parse(const uint8_t *data, size_t length) {
     return Error("Failed to read numberOfGlyphs");
   }
 
-  OpenTypeMAXP *maxp = dynamic_cast<OpenTypeMAXP*>(
-      GetFont()->GetTable(OTS_TAG_MAXP));
+  OpenTypeMAXP* maxp = static_cast<OpenTypeMAXP*>
+    (GetFont()->GetTable(OTS_TAG_MAXP));
   if (!maxp) {
     return Error("Missing required maxp table");
   }

--- a/src/post.h
+++ b/src/post.h
@@ -16,7 +16,7 @@ namespace ots {
 class OpenTypePOST : public Table {
  public:
   explicit OpenTypePOST(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_POST) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/prep.h
+++ b/src/prep.h
@@ -12,7 +12,7 @@ namespace ots {
 class OpenTypePREP : public Table {
  public:
   explicit OpenTypePREP(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_PREP) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/vdmx.h
+++ b/src/vdmx.h
@@ -34,7 +34,7 @@ struct OpenTypeVDMXGroup {
 class OpenTypeVDMX : public Table {
  public:
   explicit OpenTypeVDMX(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_VDMX) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/vhea.h
+++ b/src/vhea.h
@@ -13,7 +13,7 @@ namespace ots {
 class OpenTypeVHEA : public OpenTypeMetricsHeader {
  public:
   explicit OpenTypeVHEA(Font *font, uint32_t tag)
-      : OpenTypeMetricsHeader(font, tag) { }
+      : OpenTypeMetricsHeader(font, tag, OTS_TAG_VHEA) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/vmtx.h
+++ b/src/vmtx.h
@@ -14,7 +14,7 @@ namespace ots {
 struct OpenTypeVMTX : public OpenTypeMetricsTable {
  public:
   explicit OpenTypeVMTX(Font *font, uint32_t tag)
-      : OpenTypeMetricsTable(font, tag, OTS_TAG_VHEA) { }
+      : OpenTypeMetricsTable(font, tag, OTS_TAG_VMTX, OTS_TAG_VHEA) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);

--- a/src/vorg.h
+++ b/src/vorg.h
@@ -19,7 +19,7 @@ struct OpenTypeVORGMetrics {
 class OpenTypeVORG : public Table {
  public:
   explicit OpenTypeVORG(Font *font, uint32_t tag)
-      : Table(font, tag) { }
+      : Table(font, tag, OTS_TAG_VORG) { }
 
   bool Parse(const uint8_t *data, size_t length);
   bool Serialize(OTSStream *out);


### PR DESCRIPTION
Instead of relying on C++ RTTI, this adds an m_type field to Table, and each specific subclass constructor initializes this to the tag that corresponds to its type. This is used to implement a Font::GetTypedTable() method that checks whether the returned Table does in fact have the expected type (i.e. it wasn't loaded as unparsed data using TablePassthru), in which case it can safely be down-cast with static_cast<> by the caller.

Fixes #129.