### PR TITLE
[graphite] Match signedness in GlatEntry loop

### DIFF
--- a/src/glat.cc
+++ b/src/glat.cc
@@ -74,7 +74,7 @@ bool OpenTypeGLAT_v1::GlatEntry::ParsePart(Buffer& table) {
   }
 
   //this->attributes.resize(this->num);
-  for (unsigned i = 0; i < this->num; ++i) {
+  for (int i = 0; i < this->num; ++i) {
     this->attributes.emplace_back();
     if (!table.ReadS16(&this->attributes[i])) {
       return parent->Error("GlatEntry: Failed to read attribute %u", i);
@@ -156,7 +156,7 @@ bool OpenTypeGLAT_v2::GlatEntry::ParsePart(Buffer& table) {
   }
 
   //this->attributes.resize(this->num);
-  for (unsigned i = 0; i < this->num; ++i) {
+  for (int i = 0; i < this->num; ++i) {
     this->attributes.emplace_back();
     if (!table.ReadS16(&this->attributes[i])) {
       return parent->Error("GlatEntry: Failed to read attribute %u", i);


### PR DESCRIPTION
Silences compiler warnings during Firefox compilation. (Ultimately, GlatEntry::num should be changed to an unsigned value in the Graphite spec.)