### PR TITLE
[graphite] Fix binary-search header fields rather than dropping table

### DIFF
--- a/src/silf.cc
+++ b/src/silf.cc
@@ -278,6 +278,9 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
   if (!table.ReadU16(&this->numPseudo)) {
     return parent->Error("SILSub: Failed to read numPseudo");
   }
+
+  // The following three fields are deprecated and ignored. We fix them up here
+  // just for internal consistency, but the Graphite engine doesn't care.
   if (!table.ReadU16(&this->searchPseudo) ||
       !table.ReadU16(&this->pseudoSelector) ||
       !table.ReadU16(&this->pseudoShift)) {
@@ -285,7 +288,6 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
   }
   if (this->numPseudo == 0) {
     if (this->searchPseudo != 0 || this->pseudoSelector != 0 || this->pseudoShift != 0) {
-      parent->Warning("SILSub: Correcting binary-search header for zero-length pseudos list");
       this->searchPseudo = this->pseudoSelector = this->pseudoShift = 0;
     }
   } else {
@@ -293,7 +295,6 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
     if (this->searchPseudo != 6 * (unsigned)std::pow(2, floorLog2) ||
         this->pseudoSelector != floorLog2 ||
         this->pseudoShift != 6 * this->numPseudo - this->searchPseudo) {
-      parent->Warning("SILSub: Correcting binary-search header for pseudos list");
       this->searchPseudo = 6 * (unsigned)std::pow(2, floorLog2);
       this->pseudoSelector = floorLog2;
       this->pseudoShift = 6 * this->numPseudo - this->searchPseudo;
@@ -673,6 +674,9 @@ SILPass::ParsePart(Buffer& table, const size_t SILSub_init_offset,
   if (!table.ReadU16(&this->numRange)) {
     return parent->Error("SILPass: Failed to read numRange");
   }
+
+  // The following three fields are deprecated and ignored. We fix them up here
+  // just for internal consistency, but the Graphite engine doesn't care.
   if (!table.ReadU16(&this->searchRange) ||
       !table.ReadU16(&this->entrySelector) ||
       !table.ReadU16(&this->rangeShift)) {
@@ -680,7 +684,6 @@ SILPass::ParsePart(Buffer& table, const size_t SILSub_init_offset,
   }
   if (this->numRange == 0) {
     if (this->searchRange != 0 || this->entrySelector != 0 || this->rangeShift != 0) {
-      parent->Warning("SILPass: Correcting binary-search header for zero-length range list");
       this->searchRange = this->entrySelector = this->rangeShift = 0;
     }
   } else {
@@ -688,7 +691,6 @@ SILPass::ParsePart(Buffer& table, const size_t SILSub_init_offset,
     if (this->searchRange != 6 * (unsigned)std::pow(2, floorLog2) ||
         this->entrySelector != floorLog2 ||
         this->rangeShift != 6 * this->numRange - this->searchRange) {
-      parent->Warning("SILPass: Correcting binary-search header for range list");
       this->searchRange = 6 * (unsigned)std::pow(2, floorLog2);
       this->entrySelector = floorLog2;
       this->rangeShift = 6 * this->numRange - this->searchRange;

--- a/src/silf.cc
+++ b/src/silf.cc
@@ -278,19 +278,26 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
   if (!table.ReadU16(&this->numPseudo)) {
     return parent->Error("SILSub: Failed to read numPseudo");
   }
-  if (!table.ReadU16(&this->searchPseudo) || this->searchPseudo !=
-      (this->numPseudo == 0 ? 0 :  // protect against log2(0)
-       (unsigned)std::pow(2, std::floor(std::log2(this->numPseudo))))) {
-    return parent->Error("SILSub: Failed to read valid searchPseudo");
+  if (!table.ReadU16(&this->searchPseudo) ||
+      !table.ReadU16(&this->pseudoSelector) ||
+      !table.ReadU16(&this->pseudoShift)) {
+    return parent->Error("SILSub: Failed to read searchPseudo..pseudoShift");
   }
-  if (!table.ReadU16(&this->pseudoSelector) || this->pseudoSelector !=
-      (this->numPseudo == 0 ? 0 :  // protect against log2(0)
-       (unsigned)std::floor(std::log2(this->numPseudo)))) {
-    return parent->Error("SILSub: Failed to read valid pseudoSelector");
-  }
-  if (!table.ReadU16(&this->pseudoShift) ||
-      this->pseudoShift != this->numPseudo - this->searchPseudo) {
-    return parent->Error("SILSub: Failed to read valid pseudoShift");
+  if (this->numPseudo == 0) {
+    if (this->searchPseudo != 0 || this->pseudoSelector != 0 || this->pseudoShift != 0) {
+      parent->Warning("SILSub: Correcting binary-search header for zero-length pseudos list");
+      this->searchPseudo = this->pseudoSelector = this->pseudoShift = 0;
+    }
+  } else {
+    unsigned floorLog2 = std::floor(std::log2(this->numPseudo));
+    if (this->searchPseudo != 6 * (unsigned)std::pow(2, floorLog2) ||
+        this->pseudoSelector != floorLog2 ||
+        this->pseudoShift != 6 * this->numPseudo - this->searchPseudo) {
+      parent->Warning("SILSub: Correcting binary-search header for pseudos list");
+      this->searchPseudo = 6 * (unsigned)std::pow(2, floorLog2);
+      this->pseudoSelector = floorLog2;
+      this->pseudoShift = 6 * this->numPseudo - this->searchPseudo;
+    }
   }
 
   //this->pMaps.resize(this->numPseudo, parent);
@@ -539,19 +546,26 @@ LookupClass::ParsePart(Buffer& table) {
   if (!table.ReadU16(&this->numIDs)) {
     return parent->Error("LookupClass: Failed to read numIDs");
   }
-  if (!table.ReadU16(&this->searchRange) || this->searchRange !=
-      (this->numIDs == 0 ? 0 :  // protect against log2(0)
-       (unsigned)std::pow(2, std::floor(std::log2(this->numIDs))))) {
-    return parent->Error("LookupClass: Failed to read valid searchRange");
+  if (!table.ReadU16(&this->searchRange) ||
+      !table.ReadU16(&this->entrySelector) ||
+      !table.ReadU16(&this->rangeShift)) {
+    return parent->Error("LookupClass: Failed to read searchRange..rangeShift");
   }
-  if (!table.ReadU16(&this->entrySelector) || this->entrySelector !=
-      (this->numIDs == 0 ? 0 :  // protect against log2(0)
-       (unsigned)std::floor(std::log2(this->numIDs)))) {
-    return parent->Error("LookupClass: Failed to read valid entrySelector");
-  }
-  if (!table.ReadU16(&this->rangeShift) ||
-      this->rangeShift != this->numIDs - this->searchRange) {
-    return parent->Error("LookupClass: Failed to read valid rangeShift");
+  if (this->numIDs == 0) {
+    if (this->searchRange != 0 || this->entrySelector != 0 || this->rangeShift != 0) {
+      parent->Warning("LookupClass: Correcting binary-search header for zero-length LookupPair list");
+      this->searchRange = this->entrySelector = this->rangeShift = 0;
+    }
+  } else {
+    unsigned floorLog2 = std::floor(std::log2(this->numIDs));
+    if (this->searchRange != (unsigned)std::pow(2, floorLog2) ||
+        this->entrySelector != floorLog2 ||
+        this->rangeShift != this->numIDs - this->searchRange) {
+      parent->Warning("LookupClass: Correcting binary-search header for LookupPair list");
+      this->searchRange = (unsigned)std::pow(2, floorLog2);
+      this->entrySelector = floorLog2;
+      this->rangeShift = this->numIDs - this->searchRange;
+    }
   }
 
   //this->lookups.resize(this->numIDs, parent);
@@ -659,19 +673,26 @@ SILPass::ParsePart(Buffer& table, const size_t SILSub_init_offset,
   if (!table.ReadU16(&this->numRange)) {
     return parent->Error("SILPass: Failed to read numRange");
   }
-  if (!table.ReadU16(&this->searchRange) || this->searchRange !=
-      (this->numRange == 0 ? 0 :  // protect against log2(0)
-       (unsigned)std::pow(2, std::floor(std::log2(this->numRange))))) {
-    return parent->Error("SILPass: Failed to read valid searchRange");
+  if (!table.ReadU16(&this->searchRange) ||
+      !table.ReadU16(&this->entrySelector) ||
+      !table.ReadU16(&this->rangeShift)) {
+    return parent->Error("SILPass: Failed to read searchRange..rangeShift");
   }
-  if (!table.ReadU16(&this->entrySelector) || this->entrySelector !=
-      (this->numRange == 0 ? 0 :  // protect against log2(0)
-       (unsigned)std::floor(std::log2(this->numRange)))) {
-    return parent->Error("SILPass: Failed to read valid entrySelector");
-  }
-  if (!table.ReadU16(&this->rangeShift) ||
-      this->rangeShift != this->numRange - this->searchRange) {
-    return parent->Error("SILPass: Failed to read valid rangeShift");
+  if (this->numRange == 0) {
+    if (this->searchRange != 0 || this->entrySelector != 0 || this->rangeShift != 0) {
+      parent->Warning("SILPass: Correcting binary-search header for zero-length range list");
+      this->searchRange = this->entrySelector = this->rangeShift = 0;
+    }
+  } else {
+    unsigned floorLog2 = std::floor(std::log2(this->numRange));
+    if (this->searchRange != 6 * (unsigned)std::pow(2, floorLog2) ||
+        this->entrySelector != floorLog2 ||
+        this->rangeShift != 6 * this->numRange - this->searchRange) {
+      parent->Warning("SILPass: Correcting binary-search header for range list");
+      this->searchRange = 6 * (unsigned)std::pow(2, floorLog2);
+      this->entrySelector = floorLog2;
+      this->rangeShift = 6 * this->numRange - this->searchRange;
+    }
   }
 
   //this->ranges.resize(this->numRange, parent);

--- a/src/sill.cc
+++ b/src/sill.cc
@@ -22,6 +22,9 @@ bool OpenTypeSILL::Parse(const uint8_t* data, size_t length) {
   if (!table.ReadU16(&this->numLangs)) {
     return Drop("Failed to read numLangs");
   }
+
+  // The following three fields are deprecated and ignored. We fix them up here
+  // just for internal consistency, but the Graphite engine doesn't care.
   if (!table.ReadU16(&this->searchRange) ||
       !table.ReadU16(&this->entrySelector) ||
       !table.ReadU16(&this->rangeShift)) {
@@ -29,7 +32,6 @@ bool OpenTypeSILL::Parse(const uint8_t* data, size_t length) {
   }
   if (this->numLangs == 0) {
     if (this->searchRange != 0 || this->entrySelector != 0 || this->rangeShift != 0) {
-      Warning("Correcting binary-search header for zero-length language list");
       this->searchRange = this->entrySelector = this->rangeShift = 0;
     }
   } else {
@@ -37,7 +39,6 @@ bool OpenTypeSILL::Parse(const uint8_t* data, size_t length) {
     if (this->searchRange != (unsigned)std::pow(2, floorLog2) ||
         this->entrySelector != floorLog2 ||
         this->rangeShift != this->numLangs - this->searchRange) {
-      Warning("Correcting binary-search header for language list");
       this->searchRange = (unsigned)std::pow(2, floorLog2);
       this->entrySelector = floorLog2;
       this->rangeShift = this->numLangs - this->searchRange;


### PR DESCRIPTION
The correct values for these fields can be computed from the number of entries
in the list to be searched, so we can simply overwrite them with the proper
values rather than rejecting tables where they appear wrong.

(Existing fonts in circulation often have bad values in these fields; in
practice, it doesn't matter because the current engine does not rely on
them, and therefore the errors have not been noticed. But in case any future
engine does try to use them, we should fix them up here.)