### PR TITLE
[graphite] Fix invalid lbGID instead of dropping table

### DIFF
--- a/src/silf.cc
+++ b/src/silf.cc
@@ -253,8 +253,13 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
     }
   }
 
-  if (!table.ReadU16(&this->lbGID) || this->lbGID > this->maxGlyphID) {
-    return parent->Error("SILSub: Failed to read valid lbGID");
+  if (!table.ReadU16(&this->lbGID)) {
+    return parent->Error("SILSub: Failed to read lbGID");
+  }
+  if (this->lbGID > this->maxGlyphID) {
+    parent->Warning("SILSub: lbGID %u outside range 0..%u, replaced with 0",
+                    this->lbGID, this->maxGlyphID);
+    this->lbGID = 0;
   }
 
   if (parent->version >> 16 >= 3 &&


### PR DESCRIPTION
This field is only used by the Graphite justifier, which no client applications are
currently (known to be) using. The value in Awami (at least) is incorrect due to a
bug in the subsetter being used to generate the font served on the Graphite demo page,
but as it is unused, the error is harmless and we shouldn't reject the font.

Setting to zero should be benign; at worst, I guess a client that did attempt to use the
justifier might see spurious .notdef glyphs, but there should be no security issues
as a result.