### PR TITLE
Avoid #define-ing htons and friends

### DIFF
--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -15,13 +15,17 @@ typedef int int32_t;
 typedef unsigned int uint32_t;
 typedef __int64 int64_t;
 typedef unsigned __int64 uint64_t;
-#define ntohl(x) _byteswap_ulong (x)
-#define ntohs(x) _byteswap_ushort (x)
-#define htonl(x) _byteswap_ulong (x)
-#define htons(x) _byteswap_ushort (x)
+#define ots_ntohl(x) _byteswap_ulong (x)
+#define ots_ntohs(x) _byteswap_ushort (x)
+#define ots_htonl(x) _byteswap_ulong (x)
+#define ots_htons(x) _byteswap_ushort (x)
 #else
 #include <arpa/inet.h>
 #include <stdint.h>
+#define ots_ntohl(x) ntohl (x)
+#define ots_ntohs(x) ntohs (x)
+#define ots_htonl(x) htonl (x)
+#define ots_htons(x) htons (x)
 #endif
 
 #include <sys/types.h>
@@ -60,7 +64,7 @@ class OTSStream {
       const size_t l = std::min(length, static_cast<size_t>(4) - chksum_offset);
       uint32_t tmp = 0;
       std::memcpy(reinterpret_cast<uint8_t *>(&tmp) + chksum_offset, data, l);
-      chksum_ += ntohl(tmp);
+      chksum_ += ots_ntohl(tmp);
       length -= l;
       offset += l;
     }
@@ -69,7 +73,7 @@ class OTSStream {
       uint32_t tmp;
       std::memcpy(&tmp, reinterpret_cast<const uint8_t *>(data) + offset,
         sizeof(uint32_t));
-      chksum_ += ntohl(tmp);
+      chksum_ += ots_ntohl(tmp);
       length -= 4;
       offset += 4;
     }
@@ -79,7 +83,7 @@ class OTSStream {
       uint32_t tmp = 0;
       std::memcpy(&tmp,
                   reinterpret_cast<const uint8_t*>(data) + offset, length);
-      chksum_ += ntohl(tmp);
+      chksum_ += ots_ntohl(tmp);
     }
 
     return WriteRaw(data, orig_length);
@@ -107,27 +111,27 @@ class OTSStream {
   }
 
   bool WriteU16(uint16_t v) {
-    v = htons(v);
+    v = ots_htons(v);
     return Write(&v, sizeof(v));
   }
 
   bool WriteS16(int16_t v) {
-    v = htons(v);
+    v = ots_htons(v);
     return Write(&v, sizeof(v));
   }
 
   bool WriteU24(uint32_t v) {
-    v = htonl(v);
+    v = ots_htonl(v);
     return Write(reinterpret_cast<uint8_t*>(&v)+1, 3);
   }
 
   bool WriteU32(uint32_t v) {
-    v = htonl(v);
+    v = ots_htonl(v);
     return Write(&v, sizeof(v));
   }
 
   bool WriteS32(int32_t v) {
-    v = htonl(v);
+    v = ots_htonl(v);
     return Write(&v, sizeof(v));
   }
 

--- a/src/cmap.cc
+++ b/src/cmap.cc
@@ -238,7 +238,7 @@ bool OpenTypeCMAP::ParseFormat4(int platform, int encoding,
         }
         uint16_t glyph;
         std::memcpy(&glyph, data + glyph_id_offset, 2);
-        glyph = ntohs(glyph);
+        glyph = ots_ntohs(glyph);
         if (glyph >= num_glyphs) {
           return Error("Range glyph reference too high (%d > %d)", glyph, num_glyphs - 1);
         }

--- a/src/ots.h
+++ b/src/ots.h
@@ -112,7 +112,7 @@ class Buffer {
       return OTS_FAILURE();
     }
     std::memcpy(value, buffer_ + offset_, sizeof(uint16_t));
-    *value = ntohs(*value);
+    *value = ots_ntohs(*value);
     offset_ += 2;
     return true;
   }
@@ -137,7 +137,7 @@ class Buffer {
       return OTS_FAILURE();
     }
     std::memcpy(value, buffer_ + offset_, sizeof(uint32_t));
-    *value = ntohl(*value);
+    *value = ots_ntohl(*value);
     offset_ += 4;
     return true;
   }


### PR DESCRIPTION
`opentype-sanitiser.h` #defines `ntohl`, `ntohs`, `htonl` and `htons` on Windows.
This causes problems if other headers #included later (like Winsock2.h) tried to define these as functions.

To avoid polluting the global namespace, this patch adds `ots_` prefix to these macros.
