### PR TITLE
Fix typo in HowToTest.md (s/ckeck/check/)

### DIFF
--- a/docs/HowToTest.md
+++ b/docs/HowToTest.md
@@ -14,7 +14,7 @@ will be used.
 
 Simply run:
 
-    $ make ckeck
+    $ make check
 
 Which will run tests to verify that:
 


### PR DESCRIPTION
I verified locally that the currently-recommended command, `make ckeck`, is unrecognized, whereas the corrected `make check` command *does* actually run the tests. :)