### PR TITLE
Fix issues found by ots-fuzzer

### DIFF
--- a/src/stat.cc
+++ b/src/stat.cc
@@ -43,12 +43,13 @@ bool OpenTypeSTAT::Parse(const uint8_t* data, size_t length) {
     }
   } else {
     if (this->designAxesOffset < headerEnd ||
-        this->designAxesOffset + this->designAxisCount * this->designAxisSize > length) {
+        size_t(this->designAxesOffset) +
+          size_t(this->designAxisCount) * size_t(this->designAxisSize) > length) {
       return Drop("Invalid designAxesOffset");
     }
   }
 
-  for (unsigned i = 0; i < this->designAxisCount; i++) {
+  for (size_t i = 0; i < this->designAxisCount; i++) {
     table.set_offset(this->designAxesOffset + i * this->designAxisSize);
     this->designAxes.emplace_back();
     auto& axis = this->designAxes[i];
@@ -78,12 +79,13 @@ bool OpenTypeSTAT::Parse(const uint8_t* data, size_t length) {
     }
   } else {
     if (this->offsetToAxisValueOffsets < headerEnd ||
-        this->offsetToAxisValueOffsets + this->axisValueCount * sizeof(uint16_t) > length) {
+        size_t(this->offsetToAxisValueOffsets) +
+          size_t(this->axisValueCount) * sizeof(uint16_t) > length) {
       return Drop("Invalid offsetToAxisValueOffsets");
     }
   }
 
-  for (unsigned i = 0; i < this->axisValueCount; i++) {
+  for (size_t i = 0; i < this->axisValueCount; i++) {
     table.set_offset(this->offsetToAxisValueOffsets + i * sizeof(uint16_t));
     uint16_t axisValueOffset;
     if (!table.ReadU16(&axisValueOffset)) {

--- a/src/variations.cc
+++ b/src/variations.cc
@@ -78,7 +78,7 @@ ParseVariationDataSubtable(const ots::Font* font, const uint8_t* data, const siz
     }
   }
 
-  if (!subtable.Skip(itemCount * (shortDeltaCount + regionIndexCount))) {
+  if (!subtable.Skip(size_t(itemCount) * size_t(shortDeltaCount) + size_t(regionIndexCount))) {
     return OTS_FAILURE_MSG("Failed to read delta data");
   }
 

--- a/src/variations.cc
+++ b/src/variations.cc
@@ -125,6 +125,9 @@ ParseItemVariationStore(const Font* font, const uint8_t* data, const size_t leng
     if (!subtable.ReadU32(&offset)) {
       return OTS_FAILURE_MSG("Failed to read variation data subtable offset");
     }
+    if (offset >= length) {
+      return OTS_FAILURE_MSG("Bad offset to variation data subtable");
+    }
     if (!ParseVariationDataSubtable(font, data + offset, length - offset, regionCount)) {
       return OTS_FAILURE_MSG("Failed to parse variation data subtable");
     }


### PR DESCRIPTION
These are straightforward fixes: a missing offset check before calling a parsing function, and a few cases where offset/length computations using 16-bit fields might overflow (so we need to explicitly promote the values to at least 32-bit before doing arithmetic with them).