### PR TITLE
[STAT] Must properly construct vector<> before assigning to it.

### DIFF
--- a/src/stat.h
+++ b/src/stat.h
@@ -118,6 +118,7 @@ class OpenTypeSTAT : public Table {
         format3 = other_.format3;
         break;
       case 4:
+        new (&this->format4) AxisValueFormat4();
         format4 = other_.format4;
         break;
       }


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=7361
and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=7372