### PR TITLE
[glyf] Fix miscalculated maxp.maxSizeOfInstructions

### DIFF
--- a/src/glyf.cc
+++ b/src/glyf.cc
@@ -106,8 +106,9 @@ bool OpenTypeGLYF::ParseSimpleGlyph(Buffer &glyph,
 
   if (this->maxp->version_1 &&
       this->maxp->max_size_glyf_instructions < bytecode_length) {
-    return Error("Bytecode length is bigger than maxp.maxSizeOfInstructions "
-        "%d: %d", this->maxp->max_size_glyf_instructions, bytecode_length);
+    this->maxp->max_size_glyf_instructions = bytecode_length;
+    Warning("Bytecode length is bigger than maxp.maxSizeOfInstructions %d: %d",
+            this->maxp->max_size_glyf_instructions, bytecode_length);
   }
 
   if (!glyph.Skip(bytecode_length)) {
@@ -202,9 +203,10 @@ bool OpenTypeGLYF::ParseCompositeGlyph(Buffer &glyph) {
 
     if (this->maxp->version_1 &&
         this->maxp->max_size_glyf_instructions < bytecode_length) {
-      return Error("Bytecode length is bigger than maxp.maxSizeOfInstructions "
-                   "%d: %d",
-                   this->maxp->max_size_glyf_instructions, bytecode_length);
+      this->maxp->max_size_glyf_instructions = bytecode_length;
+      Warning("Bytecode length is bigger than maxp.maxSizeOfInstructions "
+              "%d: %d",
+              this->maxp->max_size_glyf_instructions, bytecode_length);
     }
 
     if (!glyph.Skip(bytecode_length)) {


### PR DESCRIPTION
When maxp.maxSizeOfInstructions and the bytecode mismatch, fix the former and warn instead of rejecting the font.

Fixes https://github.com/khaledhosny/ots/issues/181