### PR TITLE
[STAT] Add null-check to silence coverity warning

### DIFF
--- a/src/stat.cc
+++ b/src/stat.cc
@@ -15,7 +15,7 @@ bool OpenTypeSTAT::ValidateNameId(uint16_t nameid, bool allowPredefined) {
   OpenTypeNAME* name = static_cast<OpenTypeNAME*>(
       GetFont()->GetTypedTable(OTS_TAG_NAME));
 
-  if (!name->IsValidNameId(nameid)) {
+  if (!name || !name->IsValidNameId(nameid)) {
     Drop("Invalid nameID: %d", nameid);
     return false;
   }


### PR DESCRIPTION
Coverity is worried that `name` could be nullptr here (as `GetTypedTable` can return null). This won't actually happen, because `name` is a required table and so OTS will reject the font before it even attempts to parse `STAT` if it is missing; but I suggest we add a null-check here rather than relying on the order of table processing.