### PR TITLE
Remove unused variable INNER_INDEX_BIT_COUNT_MASK

### DIFF
--- a/src/variations.cc
+++ b/src/variations.cc
@@ -147,7 +147,6 @@ bool ParseDeltaSetIndexMap(const Font* font, const uint8_t* data, const size_t l
     return OTS_FAILURE_MSG("Failed to read delta set index map header");
   }
 
-  const uint16_t INNER_INDEX_BIT_COUNT_MASK = 0x000F;
   const uint16_t MAP_ENTRY_SIZE_MASK = 0x0030;
 
   const uint16_t entrySize = (((entryFormat & MAP_ENTRY_SIZE_MASK) >> 4) + 1);


### PR DESCRIPTION
This variable has no usages (and doesn't seem to have had any usages in the commit that added it, https://github.com/khaledhosny/ots/commit/5ae961372b0c1709f756144f0053d0a69874b794 ).

It causes a `-Wunused-variable` build warning, so let's remove it.