### PR TITLE
[variations] allow VarRegionList.RegionAxisCount be 0 when RegionCount is 0

### DIFF
--- a/src/variations.cc
+++ b/src/variations.cc
@@ -23,6 +23,10 @@ bool ParseVariationRegionList(const ots::Font* font, const uint8_t* data, const 
     return OTS_FAILURE_MSG("Failed to read variation region list header");
   }
 
+  if (*regionCount == 0) {
+    return true;
+  }
+
   const ots::OpenTypeFVAR* fvar =
     static_cast<ots::OpenTypeFVAR*>(font->GetTypedTable(OTS_TAG_FVAR));
   if (!fvar) {


### PR DESCRIPTION
OTS enforces that VarStore.VarRegionList.RegionAxisCount be always equal to the fvar.axisCount, even when the VarRegionList is empty and contains no regions.

When fonttools compiles empty VarRegionList containing no VarRegions, the RegionAxisCount defaults to 0, instead of always be equal to fvar.axisCount. This is because the count value is dynamically propagated from the length of the VarRegion.VarRegionAxis array.

@behdad argued that it should be allowed to have RegionAxisCount == 0 when the VarRegionList is empty. This PR changes OTS so that it checks VarRegionList.RegionAxisCount == fvar.axisCount only when there are any regions in the list, otherwise ignore the value.

Related issues:
https://github.com/googlefonts/fontmake/issues/565
https://github.com/fonttools/fonttools/pull/1671
https://github.com/fonttools/fonttools/issues/1670