### PR TITLE
Remove version dependent reserved value checks from silf

### DIFF
--- a/src/silf.cc
+++ b/src/silf.cc
@@ -176,14 +176,8 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
     if (!table.ReadU8(&this->attrMirroring)) {
       return parent->Error("SILSub: Failed to read attrMirroring");
     }
-    if (parent->version >> 16 < 4 && this->attrMirroring != 0) {
-      parent->Warning("SILSub: Nonzero attrMirroring (reserved before v4)");
-    }
     if (!table.ReadU8(&this->attrSkipPasses)) {
       return parent->Error("SILSub: Failed to read attrSkipPasses");
-    }
-    if (parent->version >> 16 < 4 && this->attrSkipPasses != 0) {
-      parent->Warning("SILSub: Nonzero attrSkipPasses (reserved2 before v4)");
     }
 
     if (!table.ReadU8(&this->numJLevels)) {
@@ -653,9 +647,6 @@ SILPass::ParsePart(Buffer& table, const size_t SILSub_init_offset,
     if (!table.ReadU16(&this->fsmOffset)) {
       return parent->Error("SILPass: Failed to read fsmOffset");
     }
-    if (parent->version >> 16 == 2 && this->fsmOffset != 0) {
-      parent->Warning("SILPass: Nonzero fsmOffset (reserved in SILSub v2)");
-    }
     if (!table.ReadU32(&this->pcCode) ||
         (parent->version >= 3 && this->pcCode < this->fsmOffset)) {
       return parent->Error("SILPass: Failed to read pcCode");
@@ -780,10 +771,6 @@ SILPass::ParsePart(Buffer& table, const size_t SILSub_init_offset,
   if (parent->version >> 16 >= 2) {
     if (!table.ReadU8(&this->collisionThreshold)) {
       return parent->Error("SILPass: Failed to read collisionThreshold");
-    }
-    if (parent->version >> 16 < 5 && this->collisionThreshold != 0) {
-      parent->Warning("SILPass: Nonzero collisionThreshold"
-                      " (reserved before v5)");
     }
     if (!table.ReadU16(&this->pConstraint)) {
       return parent->Error("SILPass: Failed to read pConstraint");


### PR DESCRIPTION
With reference to #196 this PR removes version dependent checks that reserved values that were given a meaning in a later version of the table specification, may only take such a value if the Silf table is of a version greater or equal to the version of the specification in which the reserved value was given the meaning. This is in response to a change in the GTF specification that says:

> Notice that reserved values do not have to be 0. In addition, some values that were transitioned from reserved to having a meaning, may also be used in Silf tables whose version number is lower than the version in which the meaning was introduced.

I have still left in the checks that currently reserved values are 0. These may be removed at a later date or when the reserved values are given meaning.

There are valid released fonts whose Silf version is lower than the version the specification says that some values in the table are not reserved, which have set valid values for those entries. These are failing OTS inappropriately.
