### PR TITLE
Graphite fixes

### DIFF
--- a/src/feat.h
+++ b/src/feat.h
@@ -34,7 +34,7 @@ class OpenTypeFEAT : public Table {
     uint32_t offset;
     uint16_t flags;
     static const uint16_t HAS_DEFAULT_SETTING = 0x4000;
-    static const uint16_t RESERVED = 0x3F00;
+    static const uint16_t RESERVED = 0x3700;
     static const uint16_t DEFAULT_SETTING = 0x00FF;
     uint16_t label;
   };

--- a/src/silf.cc
+++ b/src/silf.cc
@@ -204,11 +204,11 @@ bool OpenTypeSILF::SILSub::ParsePart(Buffer& table) {
   if (!table.ReadU8(&this->direction)) {
     return parent->Error("SILSub: Failed to read direction");
   }
-  if (!table.ReadU8(&this->attCollisions)) {
-    return parent->Error("SILSub: Failed to read attCollisions");
+  if (!table.ReadU8(&this->attrCollisions)) {
+    return parent->Error("SILSub: Failed to read attrCollisions");
   }
-  if (parent->version >> 16 < 5 && this->attCollisions != 0) {
-    parent->Warning("SILSub: Nonzero attCollisions (reserved before v5)");
+  if (parent->version < 0x40001 && this->attrCollisions != 0) {
+    parent->Warning("SILSub: Nonzero attrCollisions (reserved before v4.1)");
   }
   if (!table.ReadU8(&this->reserved4)) {
     return parent->Error("SILSub: Failed to read reserved4");
@@ -366,7 +366,7 @@ bool OpenTypeSILF::SILSub::SerializePart(OTSStream* out) const {
       !out->WriteU8(this->numUserDefn) ||
       !out->WriteU8(this->maxCompPerLig) ||
       !out->WriteU8(this->direction) ||
-      !out->WriteU8(this->attCollisions) ||
+      !out->WriteU8(this->attrCollisions) ||
       !out->WriteU8(this->reserved4) ||
       !out->WriteU8(this->reserved5) ||
       (parent->version >> 16 >= 2 &&

--- a/src/silf.h
+++ b/src/silf.h
@@ -161,7 +161,7 @@ class OpenTypeSILF : public Table {
     uint8_t numUserDefn;
     uint8_t maxCompPerLig;
     uint8_t direction;
-    uint8_t attCollisions;  // reserved3 before v5
+    uint8_t attrCollisions;  // reserved3 before v4.1
     uint8_t reserved4;
     uint8_t reserved5;
     uint8_t reserved6;


### PR DESCRIPTION
Three fixes for Graphite tables:

1. correct spelling `attCollisions` -> `attrCollisions`
2. `attrCollisions` was introduced in Silf table version 4.1, not 5.0
3. The 0x800 bit is now defined and used in the FeatureDefn flags

Thanks