### PR TITLE
[meson] split fuzzer_ldflags if isn't empty

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -231,7 +231,7 @@ executable('ots-sanitize',
 fuzzer_ldflags = []
 fuzzer_defines = []
 if get_option('fuzzer_ldflags') != ''
-  fuzzer_ldflags += [get_option('fuzzer_ldflags')]
+  fuzzer_ldflags += get_option('fuzzer_ldflags').split()
   fuzzer_defines += ['-DOTS_FUZZER_NO_MAIN']
 endif
 


### PR DESCRIPTION
Needed for https://github.com/google/oss-fuzz/pull/4089

I followed the nice approach here for integrating oss-fuzz into the project and faced with https://github.com/google/oss-fuzz/pull/4076#discussion_r451118950 so thought should improve ots also now that it helped me :)