### PR TITLE
fix typos

### DIFF
--- a/src/gdef.cc
+++ b/src/gdef.cc
@@ -83,9 +83,9 @@ bool OpenTypeGDEF::ParseAttachListTable(const uint8_t *data, size_t length) {
       if (!subtable.ReadU16(&point_index)) {
         return Error("Can't read point index %d in point %d", j, i);
       }
-      // Contour point indeces are in increasing numerical order
+      // Contour point indices are in increasing numerical order
       if (last_point_index != 0 && last_point_index >= point_index) {
-        return Error("bad contour indeces: %u >= %u",
+        return Error("bad contour indices: %u >= %u",
                     last_point_index, point_index);
       }
       last_point_index = point_index;

--- a/src/gloc.cc
+++ b/src/gloc.cc
@@ -31,7 +31,7 @@ bool OpenTypeGLOC::Parse(const uint8_t* data, size_t length) {
 
   if (this->flags & ATTRIB_IDS && this->numAttribs * sizeof(uint16_t) >
                                   table.remaining()) {
-    return DropGraphite("Failed to calulate length of locations");
+    return DropGraphite("Failed to calculate length of locations");
   }
   size_t locations_len = (table.remaining() -
     (this->flags & ATTRIB_IDS ? this->numAttribs * sizeof(uint16_t) : 0)) /

--- a/src/glyf.cc
+++ b/src/glyf.cc
@@ -236,7 +236,7 @@ bool OpenTypeGLYF::Parse(const uint8_t *data, size_t length) {
   std::vector<uint32_t> &offsets = loca->offsets;
 
   if (offsets.size() != num_glyphs + 1) {
-    return Error("Invalide glyph offsets size %ld != %d", offsets.size(), num_glyphs + 1);
+    return Error("Invalid glyph offsets size %ld != %d", offsets.size(), num_glyphs + 1);
   }
 
   std::vector<uint32_t> resulting_offsets(num_glyphs + 1);

--- a/src/gsub.cc
+++ b/src/gsub.cc
@@ -150,7 +150,7 @@ bool ParseSequenceTable(const ots::Font *font,
       return OTS_FAILURE_MSG("Failed to read substitution %d in sequence table", i);
     }
     if (substitute >= num_glyphs) {
-      return OTS_FAILURE_MSG("Bad subsitution (%d) %d > %d", i, substitute, num_glyphs);
+      return OTS_FAILURE_MSG("Bad substitution (%d) %d > %d", i, substitute, num_glyphs);
     }
   }
 

--- a/src/metrics.cc
+++ b/src/metrics.cc
@@ -58,7 +58,7 @@ bool OpenTypeMetricsHeader::Parse(const uint8_t *data, size_t length) {
 
   // skip the reserved bytes
   if (!table.Skip(8)) {
-    return Error("Failed to read reserverd bytes");
+    return Error("Failed to read reserved bytes");
   }
 
   int16_t data_format;


### PR DESCRIPTION
This commit fix various typos reported by lintian during the process
of creating a Debian package for this software.

List of lintian warnings fixed by this commit:

I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-perf Invalide Invalid
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-perf calulate calculate
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-perf indeces indices
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-perf reserverd reserved
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-perf subsitution substitution
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-sanitize Invalide Invalid
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-sanitize calulate calculate
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-sanitize indeces indices
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-sanitize reserverd reserved
I: opentype-sanitizer: spelling-error-in-binary usr/bin/ots-sanitize subsitution substitution