### PR TITLE
Increase limits for decompressed tables and files

### DIFF
--- a/src/glat.cc
+++ b/src/glat.cc
@@ -207,10 +207,10 @@ bool OpenTypeGLAT_v3::Parse(const uint8_t* data, size_t length,
       if (decompressed_size == 0) {
         return DropGraphite("Decompressed size is set to 0");
       }
-      // decompressed table must be <= OTS_MAX_DECOMP_TABLE_SIZE
-      if (decompressed_size > OTS_MAX_DECOMP_TABLE_SIZE) {
+      // decompressed table must be <= OTS_MAX_DECOMPRESSED_TABLE_SIZE
+      if (decompressed_size > OTS_MAX_DECOMPRESSED_TABLE_SIZE) {
         return DropGraphite("Decompressed size exceeds %gMB: %gMB",
-                            OTS_MAX_DECOMP_TABLE_SIZE / (1024.0 * 1024.0),
+                            OTS_MAX_DECOMPRESSED_TABLE_SIZE / (1024.0 * 1024.0),
                             decompressed_size / (1024.0 * 1024.0));
       }
       std::vector<uint8_t> decompressed(decompressed_size);

--- a/src/glat.cc
+++ b/src/glat.cc
@@ -207,9 +207,10 @@ bool OpenTypeGLAT_v3::Parse(const uint8_t* data, size_t length,
       if (decompressed_size == 0) {
         return DropGraphite("Decompressed size is set to 0");
       }
-      // decompressed table must be <= 30MB
-      if (decompressed_size > 30 * 1024 * 1024) {
-        return DropGraphite("Decompressed size exceeds 30MB: %gMB",
+      // decompressed table must be <= OTS_MAX_DECOMP_TABLE_SIZE
+      if (decompressed_size > OTS_MAX_DECOMP_TABLE_SIZE) {
+        return DropGraphite("Decompressed size exceeds %gMB: %gMB",
+                            OTS_MAX_DECOMP_TABLE_SIZE / (1024.0 * 1024.0),
                             decompressed_size / (1024.0 * 1024.0));
       }
       std::vector<uint8_t> decompressed(decompressed_size);

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -514,10 +514,10 @@ bool ProcessWOFF2(ots::FontFile *header,
   if (decompressed_size == 0) {
     return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 is set to 0");
   }
-  // decompressed font must be <= OTS_MAX_DECOMP_FILE_SIZE
-  if (decompressed_size > OTS_MAX_DECOMP_FILE_SIZE) {
+  // decompressed font must be <= OTS_MAX_DECOMPRESSED_FILE_SIZE
+  if (decompressed_size > OTS_MAX_DECOMPRESSED_FILE_SIZE) {
     return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds %gMB",
-                               OTS_MAX_DECOMP_FILE_SIZE / (1024.0 * 1024.0));
+                               OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));
   }
 
   std::string buf(decompressed_size, 0);
@@ -631,14 +631,14 @@ bool ProcessGeneric(ots::FontFile *header,
     if (tables[i].uncompressed_length > tables[i].length) {
       // We'll probably be decompressing this table.
 
-      // disallow all tables which uncompress to > OTS_MAX_DECOMP_TABLE_SIZE
-      if (tables[i].uncompressed_length > OTS_MAX_DECOMP_TABLE_SIZE) {
-        return OTS_FAILURE_MSG_HDR("%c%c%c%c: uncompressed table length exceeds %gMB",
+      // disallow all tables which decompress to > OTS_MAX_DECOMPRESSED_TABLE_SIZE
+      if (tables[i].uncompressed_length > OTS_MAX_DECOMPRESSED_TABLE_SIZE) {
+        return OTS_FAILURE_MSG_HDR("%c%c%c%c: decompressed table length exceeds %gMB",
                                    OTS_UNTAG(tables[i].tag),
-                                   OTS_MAX_DECOMP_TABLE_SIZE / (1024.0 * 1024.0));        
+                                   OTS_MAX_DECOMPRESSED_TABLE_SIZE / (1024.0 * 1024.0));        
       }
       if (uncompressed_sum + tables[i].uncompressed_length < uncompressed_sum) {
-        return OTS_FAILURE_MSG_TAG("overflow of uncompressed sum", tables[i].tag);
+        return OTS_FAILURE_MSG_TAG("overflow of decompressed sum", tables[i].tag);
       }
 
       uncompressed_sum += tables[i].uncompressed_length;
@@ -655,10 +655,10 @@ bool ProcessGeneric(ots::FontFile *header,
     }
   }
 
-  // All decompressed tables uncompressed must be <= OTS_MAX_DECOMP_FILE_SIZE.
-  if (uncompressed_sum > OTS_MAX_DECOMP_FILE_SIZE) {
-    return OTS_FAILURE_MSG_HDR("uncompressed sum exceeds %gMB",
-                               OTS_MAX_DECOMP_FILE_SIZE / (1024.0 * 1024.0));        
+  // All decompressed tables decompressed must be <= OTS_MAX_DECOMPRESSED_FILE_SIZE.
+  if (uncompressed_sum > OTS_MAX_DECOMPRESSED_FILE_SIZE) {
+    return OTS_FAILURE_MSG_HDR("decompressed sum exceeds %gMB",
+                               OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));        
   }
 
   // check that the tables are not overlapping.

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -514,9 +514,10 @@ bool ProcessWOFF2(ots::FontFile *header,
   if (decompressed_size == 0) {
     return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 is set to 0");
   }
-  // decompressed font must be <= 30MB
-  if (decompressed_size > 30 * 1024 * 1024) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds 30MB");
+  // decompressed font must be <= OTS_MAX_DECOMP_FILE_SIZE
+  if (decompressed_size > OTS_MAX_DECOMP_FILE_SIZE) {
+    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds %gMB",
+                               OTS_MAX_DECOMP_FILE_SIZE / (1024.0 * 1024.0));
   }
 
   std::string buf(decompressed_size, 0);
@@ -630,9 +631,11 @@ bool ProcessGeneric(ots::FontFile *header,
     if (tables[i].uncompressed_length > tables[i].length) {
       // We'll probably be decompressing this table.
 
-      // disallow all tables which uncompress to > 30 MB
-      if (tables[i].uncompressed_length > 30 * 1024 * 1024) {
-        return OTS_FAILURE_MSG_TAG("uncompressed length exceeds 30MB", tables[i].tag);
+      // disallow all tables which uncompress to > OTS_MAX_DECOMP_TABLE_SIZE
+      if (tables[i].uncompressed_length > OTS_MAX_DECOMP_TABLE_SIZE) {
+        return OTS_FAILURE_MSG_HDR("%c%c%c%c: uncompressed table length exceeds %gMB",
+                                   OTS_UNTAG(tables[i].tag),
+                                   OTS_MAX_DECOMP_TABLE_SIZE / (1024.0 * 1024.0));        
       }
       if (uncompressed_sum + tables[i].uncompressed_length < uncompressed_sum) {
         return OTS_FAILURE_MSG_TAG("overflow of uncompressed sum", tables[i].tag);
@@ -652,9 +655,10 @@ bool ProcessGeneric(ots::FontFile *header,
     }
   }
 
-  // All decompressed tables uncompressed must be <= 30MB.
-  if (uncompressed_sum > 30 * 1024 * 1024) {
-    return OTS_FAILURE_MSG_HDR("uncompressed sum exceeds 30MB");
+  // All decompressed tables uncompressed must be <= OTS_MAX_DECOMP_FILE_SIZE.
+  if (uncompressed_sum > OTS_MAX_DECOMP_FILE_SIZE) {
+    return OTS_FAILURE_MSG_HDR("uncompressed sum exceeds %gMB",
+                               OTS_MAX_DECOMP_FILE_SIZE / (1024.0 * 1024.0));        
   }
 
   // check that the tables are not overlapping.

--- a/src/ots.h
+++ b/src/ots.h
@@ -232,8 +232,9 @@ bool IsValidVersionTag(uint32_t tag);
 #define OTS_TAG_VVAR OTS_TAG('V','V','A','R')
 #define OTS_TAG_STAT OTS_TAG('S','T','A','T')
 
-#define OTS_MAX_DECOMP_FILE_SIZE 300 * 1024 * 1024
-#define OTS_MAX_DECOMP_TABLE_SIZE 150 * 1024 * 1024
+// See https://github.com/khaledhosny/ots/issues/219
+#define OTS_MAX_DECOMPRESSED_FILE_SIZE 300 * 1024 * 1024
+#define OTS_MAX_DECOMPRESSED_TABLE_SIZE 150 * 1024 * 1024
 
 struct Font;
 struct FontFile;

--- a/src/ots.h
+++ b/src/ots.h
@@ -232,6 +232,9 @@ bool IsValidVersionTag(uint32_t tag);
 #define OTS_TAG_VVAR OTS_TAG('V','V','A','R')
 #define OTS_TAG_STAT OTS_TAG('S','T','A','T')
 
+#define OTS_MAX_DECOMP_FILE_SIZE 300 * 1024 * 1024
+#define OTS_MAX_DECOMP_TABLE_SIZE 150 * 1024 * 1024
+
 struct Font;
 struct FontFile;
 struct TableEntry;

--- a/src/silf.cc
+++ b/src/silf.cc
@@ -42,9 +42,10 @@ bool OpenTypeSILF::Parse(const uint8_t* data, size_t length,
         if (decompressed_size == 0) {
           return DropGraphite("Decompressed size is set to 0");
         }
-        // decompressed table must be <= 30MB
-        if (decompressed_size > 30 * 1024 * 1024) {
-          return DropGraphite("Decompressed size exceeds 30MB: %gMB",
+        // decompressed table must be <= OTS_MAX_DECOMP_TABLE_SIZE
+        if (decompressed_size > OTS_MAX_DECOMP_TABLE_SIZE) {
+          return DropGraphite("Decompressed size exceeds %gMB: %gMB",
+                              OTS_MAX_DECOMP_TABLE_SIZE / (1024.0 * 1024.0),
                               decompressed_size / (1024.0 * 1024.0));
         }
         std::vector<uint8_t> decompressed(decompressed_size);

--- a/src/silf.cc
+++ b/src/silf.cc
@@ -42,10 +42,10 @@ bool OpenTypeSILF::Parse(const uint8_t* data, size_t length,
         if (decompressed_size == 0) {
           return DropGraphite("Decompressed size is set to 0");
         }
-        // decompressed table must be <= OTS_MAX_DECOMP_TABLE_SIZE
-        if (decompressed_size > OTS_MAX_DECOMP_TABLE_SIZE) {
+        // decompressed table must be <= OTS_MAX_DECOMPRESSED_TABLE_SIZE
+        if (decompressed_size > OTS_MAX_DECOMPRESSED_TABLE_SIZE) {
           return DropGraphite("Decompressed size exceeds %gMB: %gMB",
-                              OTS_MAX_DECOMP_TABLE_SIZE / (1024.0 * 1024.0),
+                              OTS_MAX_DECOMPRESSED_TABLE_SIZE / (1024.0 * 1024.0),
                               decompressed_size / (1024.0 * 1024.0));
         }
         std::vector<uint8_t> decompressed(decompressed_size);


### PR DESCRIPTION
- add `OTS_MAX_DECOMPRESSED_FILE_SIZE` and `OTS_MAX_DECOMPRESSED_TABLE_SIZE` constants
- replace previous limit values with those constants
- minor updates to the related failure messaging

Closes #219 
