### PR TITLE
Rewrite manual page in mdoc(7)

### DIFF
--- a/docs/ots-sanitize.1
+++ b/docs/ots-sanitize.1
@@ -1,42 +1,49 @@
-.TH OTS-SANITIZE "1" "November 2020" "OpenType Sanitizer" "User Commands"
-.SH NAME
-ots-sanitize \- font validator and transcoder
-.SH SYNOPSIS
-.B yes
-[\fI\,OPTIONS\/\fR]... \fI\,FONT_FILE\/\fR [\fI\,DEST_FONT_FILE\/\fR] [\fI\,FONT_INDEX\/\fR]
-.SH DESCRIPTION
-.\" Add any additional description here
-.PP
-ots-sanitize is a program which validates and/or transcodes a font file using
-the OTS library.
-.PP
-The OpenType Sanitizer (OTS) parses and serializes OpenType files (OTF, TTF)
+.Dd November 2020
+.Dt OTS-SANITIZE 1
+.Os
+.Sh NAME
+.Nm ots-sanitize
+.Nd font validator and transcoder
+.
+.Sh SYNOPSIS
+.Nm
+.	Op Fl -quiet
+.	Ar    FONT_FILE
+.	Op Ar DEST_FONT_FILE
+.	Op Ar FONT_INDEX
+.Nm
+.	Fl -version
+.
+.Sh DESCRIPTION
+.Nm
+is a program which validates and/or transcodes a font file using the OTS library.
+.Pp
+The OpenType Sanitizer (OTS) parses and serializes OpenType files (OTF, TTF) \
 and WOFF and WOFF2 font files, validating them and sanitizing them as it goes.
-.TP
-\fB\-\-quiet\fR
-do not display information or error messages
-.TP
-\fB\-\-version\fR
-output version information and exit
-.SH EXAMPLES
+.
+.Bl -tag -width 6n
+.It Fl -quiet
+Do not display information or error messages.
+.It Fl -version
+Output version information and exit.
+.El
+.
+.Sh EXAMPLES
 Sanitize a sample and save it to another file:
-.PP
-.RS
-.nf
-$ ots-sanitize sample.otf transcoded_sample.otf
+.Dl $ ots-sanitize sample.otf transcoded_sample.otf
+.Bd -literal -offset \n[doc-display-indent]
 File sanitized successfully!
-.fi
-.RE
-.PP
+.Ed
+.
+.Pp
 Try to sanitize a malformed file:
-.PP
-.RS
-.nf
-$ ots-sanitize malformed.ttf
+.Dl $ ots-sanitize malformed.ttf
+.Bd -literal -offset \n[doc-display-indent]
 WARNING: bad range shift
 ERROR at src/ots.cc:670 (ProcessGeneric)
 Failed to sanitize file!
-.RE
-.fi
-.SH "REPORTING BUGS"
-Report bugs to  <https://github.com/khaledhosny/ots/issues>
+.Ed
+.
+.Sh BUGS
+Report bugs to
+.Lk https://github.com/khaledhosny/ots/issues .


### PR DESCRIPTION
> From a [suggestion](https://github.com/khaledhosny/ots/commit/d4e981df41efae4d1016893f1a192430c406a220#r45167406) I left on d4e981d, folded into a PR as per @khaledhosny's request.

## Description
The changes applied by this pull-request replace the use of legacy [`man(7)`][man] macros with a modern alternative: [`mdoc(7)`][mdoc].

Practical benefits include:
1. Consistent output, both in structure and formatting
2. Semantic, self-documenting markup
3. Clearer syntax. E.g., authors need not write `-` as `\-` to output ASCII hyphen-minus (U+002D) instead of Unicode hyphen (U+2010).

## Preview

<img src="https://user-images.githubusercontent.com/2346707/102342774-cfbcfb80-3fed-11eb-891a-7a1b09ed6bf3.gif" alt="Figure 1" width="640" />

The files used to generate the above frames are attached in pre-formatted (“catman”) form:
- **Before:** [man.txt](https://github.com/khaledhosny/ots/files/5702323/man.txt)
- **After:** [mdoc.txt](https://github.com/khaledhosny/ots/files/5702330/mdoc.txt)

[man]: http://man.openbsd.org/man.7
[mdoc]: http://man.openbsd.org/mdoc.7