### PR TITLE
Fix wrong command name “yes” in SYNOPSIS section of man page ots-sanitize.1

### DIFF
--- a/docs/ots-sanitize.1
+++ b/docs/ots-sanitize.1
@@ -2,7 +2,7 @@
 .SH NAME
 ots-sanitize \- font validator and transcoder
 .SH SYNOPSIS
-.B yes
+.B ots-sanitize
 [\fI\,OPTIONS\/\fR]... \fI\,FONT_FILE\/\fR [\fI\,DEST_FONT_FILE\/\fR] [\fI\,FONT_INDEX\/\fR]
 .SH DESCRIPTION
 .\" Add any additional description here


### PR DESCRIPTION
This was presumably left over from using `yes.1` as a template.