### PR TITLE
Exit early if decompressed size exceeds OTSStream's size limit

### DIFF
--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -58,7 +58,7 @@ class OTSStream {
 
   virtual ~OTSStream() {}
 
-  virtual size_t SizeLimit() = 0;
+  virtual size_t size() = 0;
 
   // This should be implemented to perform the actual write.
   virtual bool WriteRaw(const void *data, size_t length) = 0;

--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -58,6 +58,8 @@ class OTSStream {
 
   virtual ~OTSStream() {}
 
+  virtual size_t SizeLimit() = 0;
+
   // This should be implemented to perform the actual write.
   virtual bool WriteRaw(const void *data, size_t length) = 0;
 

--- a/include/ots-memory-stream.h
+++ b/include/ots-memory-stream.h
@@ -18,7 +18,7 @@ class MemoryStream : public OTSStream {
       : ptr_(ptr), length_(length), off_(0) {
   }
 
-  virtual size_t SizeLimit() { return length_; }
+  size_t size() override { return length_; }
 
   virtual bool WriteRaw(const void *data, size_t length) {
     if ((off_ + length > length_) ||
@@ -62,7 +62,7 @@ class ExpandingMemoryStream : public OTSStream {
     return ptr_;
   }
 
-  size_t SizeLimit() { return limit_; }
+  size_t size() override { return limit_; }
 
   bool WriteRaw(const void *data, size_t length) {
     if ((off_ + length > length_) ||

--- a/include/ots-memory-stream.h
+++ b/include/ots-memory-stream.h
@@ -18,6 +18,8 @@ class MemoryStream : public OTSStream {
       : ptr_(ptr), length_(length), off_(0) {
   }
 
+  virtual size_t SizeLimit() { return length_; }
+
   virtual bool WriteRaw(const void *data, size_t length) {
     if ((off_ + length > length_) ||
         (length > std::numeric_limits<size_t>::max() - off_)) {
@@ -59,6 +61,8 @@ class ExpandingMemoryStream : public OTSStream {
   void* get() const {
     return ptr_;
   }
+
+  virtual size_t SizeLimit() { return limit_; }
 
   bool WriteRaw(const void *data, size_t length) {
     if ((off_ + length > length_) ||

--- a/include/ots-memory-stream.h
+++ b/include/ots-memory-stream.h
@@ -62,7 +62,7 @@ class ExpandingMemoryStream : public OTSStream {
     return ptr_;
   }
 
-  virtual size_t SizeLimit() { return limit_; }
+  size_t SizeLimit() { return limit_; }
 
   bool WriteRaw(const void *data, size_t length) {
     if ((off_ + length > length_) ||

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -531,8 +531,8 @@ bool ProcessWOFF2(ots::FontFile *header,
                                OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));
   }
 
-  if (decompressed_size > output->SizeLimit()) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds output size (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
+  if (decompressed_size > output->size()) {
+    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds output size (%gMB)", output->size() / (1024.0 * 1024.0));
   }
 
   std::string buf(decompressed_size, 0);
@@ -676,8 +676,8 @@ bool ProcessGeneric(ots::FontFile *header,
                                OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));        
   }
 
-  if (uncompressed_sum > output->SizeLimit()) {
-    return OTS_FAILURE_MSG_HDR("decompressed sum exceeds output size (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
+  if (uncompressed_sum > output->size()) {
+    return OTS_FAILURE_MSG_HDR("decompressed sum exceeds output size (%gMB)", output->size() / (1024.0 * 1024.0));
   }
 
   // check that the tables are not overlapping.

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -677,7 +677,7 @@ bool ProcessGeneric(ots::FontFile *header,
   }
 
   if (uncompressed_sum > output->SizeLimit()) {
-    return OTS_FAILURE_MSG_HDR("decompressed sum exceeds OTSStream's size limit (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
+    return OTS_FAILURE_MSG_HDR("decompressed sum exceeds output size (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
   }
 
   // check that the tables are not overlapping.

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -532,7 +532,7 @@ bool ProcessWOFF2(ots::FontFile *header,
   }
 
   if (decompressed_size > output->SizeLimit()) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds OTSStream's size limit (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
+    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds output size (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
   }
 
   std::string buf(decompressed_size, 0);

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -531,6 +531,10 @@ bool ProcessWOFF2(ots::FontFile *header,
                                OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));
   }
 
+  if (decompressed_size > output->SizeLimit()) {
+    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds OTSStream's size limit (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
+  }
+
   std::string buf(decompressed_size, 0);
   woff2::WOFF2StringOut out(&buf);
   if (!woff2::ConvertWOFF2ToTTF(data, length, &out)) {
@@ -670,6 +674,10 @@ bool ProcessGeneric(ots::FontFile *header,
   if (uncompressed_sum > OTS_MAX_DECOMPRESSED_FILE_SIZE) {
     return OTS_FAILURE_MSG_HDR("decompressed sum exceeds %gMB",
                                OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));        
+  }
+
+  if (uncompressed_sum > output->SizeLimit()) {
+    return OTS_FAILURE_MSG_HDR("decompressed sum exceeds OTSStream's size limit (%gMB)", output->SizeLimit() / (1024.0 * 1024.0));
   }
 
   // check that the tables are not overlapping.

--- a/util/ots-sanitize.cc
+++ b/util/ots-sanitize.cc
@@ -40,7 +40,7 @@ class FileStream : public ots::OTSStream {
     }
   }
 
-  size_t SizeLimit() { return std::numeric_limits<off_t>::max(); }
+  virtual size_t SizeLimit() { return std::numeric_limits<off_t>::max(); }
 
   bool WriteRaw(const void *data, size_t length) {
     off_ += length;

--- a/util/ots-sanitize.cc
+++ b/util/ots-sanitize.cc
@@ -40,7 +40,7 @@ class FileStream : public ots::OTSStream {
     }
   }
 
-  virtual size_t SizeLimit() { return std::numeric_limits<off_t>::max(); }
+  size_t size() override { return std::numeric_limits<off_t>::max(); }
 
   bool WriteRaw(const void *data, size_t length) {
     off_ += length;

--- a/util/ots-sanitize.cc
+++ b/util/ots-sanitize.cc
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,8 @@ class FileStream : public ots::OTSStream {
       file_ = true;
     }
   }
+
+  size_t SizeLimit() { return std::numeric_limits<off_t>::max(); }
 
   bool WriteRaw(const void *data, size_t length) {
     off_ += length;


### PR DESCRIPTION
Currently we are exiting early if decompressed size exceeds
OTS_MAX_DECOMPRESSED_FILE_SIZE=300MB but some callers may actually set a
smaller limit. For example, Chromium uses 30MB [1] and its internal
fuzzer 256kB [2]. Firefox uses a limit of 256MB [3].

[1] https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/fonts/web_font_decoder.cc;l=155;drc=5863e513ede6d1f7e9a060f13635fd3916a2183c
[2] https://source.chromium.org/chromium/chromium/src/+/main:third_party/ots/fuzz/ots_fuzzer.cc;l=11;drc=efffce8e2a6da2d2295472ed24ef040e0bf4ea14
[3] https://searchfox.org/mozilla-central/rev/3e1a721bce1da3ae04675539b39a4e95b25a046d/gfx/thebes/gfxOTSUtils.h#28