### PR TITLE
[variations] Fix potential leak if initializing a synthetic gvar table fails

### DIFF
--- a/src/ots.cc
+++ b/src/ots.cc
@@ -745,6 +745,8 @@ bool ProcessGeneric(ots::FontFile *header,
     if (gvar->InitEmpty()) {
       table_map[OTS_TAG_GVAR] = { OTS_TAG_GVAR, 0, 0, 0, 0 };
       font->AddTable(gvar);
+    } else {
+      delete gvar;
     }
   }
 #endif


### PR DESCRIPTION
Trivial fix: it's unlikely to happen in practice, but if gvar->InitEmpty() were ever to fail, we'd leak the gvar object.