### PR TITLE
[review] Set the correct values in the max size of glyf instructions warning.

### DIFF
--- a/src/glyf.cc
+++ b/src/glyf.cc
@@ -112,9 +112,9 @@ bool OpenTypeGLYF::ParseSimpleGlyph(Buffer &glyph,
 
   if (this->maxp->version_1 &&
       this->maxp->max_size_glyf_instructions < bytecode_length) {
-    this->maxp->max_size_glyf_instructions = bytecode_length;
     Warning("Bytecode length is bigger than maxp.maxSizeOfInstructions %d: %d",
             this->maxp->max_size_glyf_instructions, bytecode_length);
+    this->maxp->max_size_glyf_instructions = bytecode_length;
   }
 
   if (!glyph.Skip(bytecode_length)) {
@@ -215,10 +215,10 @@ bool OpenTypeGLYF::ParseCompositeGlyph(
 
     if (this->maxp->version_1 &&
         this->maxp->max_size_glyf_instructions < bytecode_length) {
-      this->maxp->max_size_glyf_instructions = bytecode_length;
       Warning("Bytecode length is bigger than maxp.maxSizeOfInstructions "
               "%d: %d",
               this->maxp->max_size_glyf_instructions, bytecode_length);
+      this->maxp->max_size_glyf_instructions = bytecode_length;
     }
 
     if (!glyph.Skip(bytecode_length)) {


### PR DESCRIPTION
I have a font giving an ots warning:

```
WARNING: glyf: Bytecode length is bigger than maxp.maxSizeOfInstructions 4937: 4937
```

This confused me a little until I looked at the code. I believe the warning should be printed before the `maxp` value is updated.