### PR TITLE
Fix comparison of integer expressions of different signedness

### DIFF
--- a/src/cff_charstring.cc
+++ b/src/cff_charstring.cc
@@ -384,7 +384,7 @@ bool ExecuteCharStringOperator(ots::OpenTypeCFF& cff,
     }
     uint16_t k = cff.region_index_count.at(cs_ctx.vsindex);
     uint16_t n = argument_stack->top();
-    if (stack_size < n * (k + 1) + 1) {
+    if (stack_size < n * (k + 1u) + 1u) {
       return OTS_FAILURE();
     }
 


### PR DESCRIPTION
This triggers a warning we can avoid:

        src/cff_charstring.cc:387:20: warning: comparison of integer expressions of different signedness: ‘const size_t’ {aka ‘const long unsigned int’} and ‘int’ [-Wsign-compare]