### PR TITLE
[maxp] Attempt to improve fixup of bad 'maxp' version numbers.

### DIFF
--- a/src/maxp.cc
+++ b/src/maxp.cc
@@ -29,39 +29,49 @@ bool OpenTypeMAXP::Parse(const uint8_t *data, size_t length) {
     return Error("numGlyphs is 0");
   }
 
-  if (version >> 16 == 1) {
-    this->version_1 = true;
-    if (!table.ReadU16(&this->max_points) ||
-        !table.ReadU16(&this->max_contours) ||
-        !table.ReadU16(&this->max_c_points) ||
-        !table.ReadU16(&this->max_c_contours) ||
-        !table.ReadU16(&this->max_zones) ||
-        !table.ReadU16(&this->max_t_points) ||
-        !table.ReadU16(&this->max_storage) ||
-        !table.ReadU16(&this->max_fdefs) ||
-        !table.ReadU16(&this->max_idefs) ||
-        !table.ReadU16(&this->max_stack) ||
-        !table.ReadU16(&this->max_size_glyf_instructions) ||
-        !table.ReadU16(&this->max_c_components) ||
-        !table.ReadU16(&this->max_c_depth)) {
-      return Error("Failed to read version 1 table data");
-    }
+  this->version_1 = false;
 
-    if (this->max_zones == 0) {
-      // workaround for ipa*.ttf Japanese fonts.
-      Warning("Bad maxZones: %u", this->max_zones);
-      this->max_zones = 1;
-    } else if (this->max_zones == 3) {
-      // workaround for Ecolier-*.ttf fonts.
-      Warning("Bad maxZones: %u", this->max_zones);
-      this->max_zones = 2;
-    }
+  // Per https://learn.microsoft.com/en-gb/typography/opentype/spec/maxp,
+  // the only two 'maxp' version numbers are 0.5 (for CFF/CFF2) and 1.0
+  // (for TrueType).
+  // If it's version 0.5, there is nothing more to read.
+  if (version == 0x00005000) {
+    return true;
+  }
 
-    if ((this->max_zones != 1) && (this->max_zones != 2)) {
-      return Error("Bad maxZones: %u", this->max_zones);
-    }
-  } else {
-    this->version_1 = false;
+  if (version != 0x00010000) {
+    Warning("Unexpected version 0x%08x; attempting to read as version 1.0",
+            version);
+  }
+
+  // Otherwise, try to read the version 1.0 fields:
+  if (!table.ReadU16(&this->max_points) ||
+      !table.ReadU16(&this->max_contours) ||
+      !table.ReadU16(&this->max_c_points) ||
+      !table.ReadU16(&this->max_c_contours) ||
+      !table.ReadU16(&this->max_zones) ||
+      !table.ReadU16(&this->max_t_points) ||
+      !table.ReadU16(&this->max_storage) ||
+      !table.ReadU16(&this->max_fdefs) ||
+      !table.ReadU16(&this->max_idefs) ||
+      !table.ReadU16(&this->max_stack) ||
+      !table.ReadU16(&this->max_size_glyf_instructions) ||
+      !table.ReadU16(&this->max_c_components) ||
+      !table.ReadU16(&this->max_c_depth)) {
+    Warning("Failed to read version 1.0 fields, downgrading to version 0.5");
+    return true;
+  }
+
+  this->version_1 = true;
+
+  if (this->max_zones < 1) {
+    // workaround for ipa*.ttf Japanese fonts.
+    Warning("Bad maxZones: %u", this->max_zones);
+    this->max_zones = 1;
+  } else if (this->max_zones > 2) {
+    // workaround for Ecolier-*.ttf fonts and bad fonts in some PDFs
+    Warning("Bad maxZones: %u", this->max_zones);
+    this->max_zones = 2;
   }
 
   return true;


### PR DESCRIPTION
If the version number is less than 0x00010000 (e.g. an example reported at https://github.com/mozilla/pdf.js/issues/16839 apparently has 0x0100), it will be treated as version 0.5 and only the num_glyphs field is kept.

However, this can prevent the font working on Windows, which apparently requires the full version 1.0 maxp table for truetype fonts.

So if the version number was bad, but there is in fact enough data to parse as version 1.0, let's try correcting it to 1.0 rather than 0.5.

(Test not included because the example in the issue appears to be a derivative of a proprietary font.)