### PR TITLE
Fix a size_t/off_t mismatch build warning

### DIFF
--- a/include/ots-memory-stream.h
+++ b/include/ots-memory-stream.h
@@ -26,7 +26,7 @@ class MemoryStream : public OTSStream {
       return false;
     }
     std::memcpy(static_cast<char*>(ptr_) + off_, data, length);
-    off_ += length;
+    off_ += static_cast<off_t>(length);
     return true;
   }
 
@@ -82,7 +82,7 @@ class ExpandingMemoryStream : public OTSStream {
       return WriteRaw(data, length);
     }
     std::memcpy(static_cast<char*>(ptr_) + off_, data, length);
-    off_ += length;
+    off_ += static_cast<off_t>(length);
     return true;
   }
 


### PR DESCRIPTION
Fixes a build warning on builds where off_t and size_t are different.