### PR TITLE
[colr] Make rejecting paint-graph cycles in COLRv1 a compile-time option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -24,6 +24,10 @@ if get_option('synthesize-gvar')
   conf.set('OTS_SYNTHESIZE_MISSING_GVAR', 1)
 endif
 
+if get_option('colr-cycle-check')
+  conf.set('OTS_COLR_CYCLE_CHECK', 1)
+endif
+
 freetype = dependency('freetype2', required: false)
 if freetype.found()
   conf.set('HAVE_FREETYPE', 1)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
+option('colr-cycle-check', type : 'boolean', value : true, description : 'Reject fonts with cycles in COLRv1 paint graph')
 option('graphite', type : 'boolean', value : true, description : 'Sanitize Graphite tables')
 option('synthesize-gvar', type : 'boolean', value : true, description : 'Synthesize an empty gvar if fvar is present')
 option('fuzzer_ldflags', type: 'string', description : 'Extra LDFLAGS used during linking of fuzzing binaries')

--- a/src/colr.cc
+++ b/src/colr.cc
@@ -193,7 +193,15 @@ bool ParsePaintColrLayers(const ots::Font* font,
                           colrState& state)
 {
   if (setContains(state.visited, data)) {
+#ifdef OTS_COLR_CYCLE_CHECK
+    // A cycle would imply an infinite loop during painting, unless the renderer
+    // detects and breaks it. To be safe, reject the table.
     return OTS_FAILURE_MSG("Cycle detected in PaintColrLayers");
+#else
+    // Just issue a warning and return (as we've already checked this subgraph).
+    OTS_WARNING("Cycle detected in COLRv1 glyph paint graph (PaintColrLayers)\n");
+    return true;
+#endif
   }
   state.visited.insert(data);
 
@@ -393,7 +401,12 @@ bool ParsePaintColrGlyph(const ots::Font* font,
                          colrState& state)
 {
   if (setContains(state.visited, data)) {
+#ifdef OTS_COLR_CYCLE_CHECK
     return OTS_FAILURE_MSG("Cycle detected in PaintColrGlyph");
+#else
+    OTS_WARNING("Cycle detected in COLRv1 glyph paint graph (PaintColrGlyph)\n");
+    return true;
+#endif
   }
   state.visited.insert(data);
 


### PR DESCRIPTION
This will allow clients that handle cycles safely at rendering time to disable the OTS rejection.

Motivated by https://bugzilla.mozilla.org/show_bug.cgi?id=1870240.

(cc @drott)
