### PR TITLE
Set correct max_size for woff2 decompress output buffer

### DIFF
--- a/src/ots.cc
+++ b/src/ots.cc
@@ -544,6 +544,7 @@ bool ProcessWOFF2(ots::FontFile *header,
 
   std::string buf(decompressed_size, 0);
   woff2::WOFF2StringOut out(&buf);
+  out.SetMaxSize(decompressed_size);
   if (!woff2::ConvertWOFF2ToTTF(data, length, &out)) {
     return OTS_FAILURE_MSG_HDR("Failed to convert WOFF 2.0 font to SFNT");
   }


### PR DESCRIPTION
This pull request addresses the issue in https://github.com/khaledhosny/ots/issues/219.

The [original PR](https://github.com/khaledhosny/ots/pull/229) did not fully fix the issue of 30MB limit.

The current code still fails for fonts >30MB uncompressed when calling [woff2::ConvertWOFF2ToTTF](https://github.com/khaledhosny/ots/blob/27d63ae4d8988619e0a661bf40551c47da47f3fa/src/ots.cc#L547).

The issue is that the constructor of WOFF2StringOut [sets the maxSize](https://github.com/google/woff2/blob/0f4d304faa1c62994536dc73510305c7357da8d4/src/woff2_out.cc#L14) of the buffer to `kDefaultMaxSize`, which is also set to [30MB](https://github.com/google/woff2/blob/0f4d304faa1c62994536dc73510305c7357da8d4/include/woff2/output.h#L20)

To properly fix this, we will need to ensure the maxSize of the output buffer is set correctly.