### PR TITLE
Warn rather than fail if min/max of a condition table range are reversed

### DIFF
--- a/src/layout.cc
+++ b/src/layout.cc
@@ -1145,11 +1145,15 @@ bool ParseConditionTable(const ots::Font *font,
     return OTS_FAILURE_MSG("Axis index out of range in condition");
   }
 
-  // Check min/max values are within range -1.0 .. 1.0 and properly ordered
+  // Check min/max values are within range -1.0 .. 1.0.
   if (filter_range_min_value < -0x4000 || // -1.0 in F2DOT14 format
-      filter_range_max_value > 0x4000 || // +1.0 in F2DOT14 format
-      filter_range_min_value > filter_range_max_value) {
+      filter_range_max_value > 0x4000) { // +1.0 in F2DOT14 format
     return OTS_FAILURE_MSG("Invalid filter range in condition");
+  }
+
+  // Warn if range is improperly ordered (and therefore useless).
+  if (filter_range_min_value > filter_range_max_value) {
+    OTS_WARNING("Misordered filter range in condition table");
   }
 
   return true;


### PR DESCRIPTION
An improperly ordered filter range is a non-fatal error; just issue a warning.

Condition table format 1 is described at
https://learn.microsoft.com/en-gb/typography/opentype/spec/chapter2#condition-table-format-1-font-variation-axis-range

In mozilla bug https://bugzilla.mozilla.org/show_bug.cgi?id=1916037, we saw fonts being rejected due to incorrectly-ordered min/max values in this table, but this does not need to be a hard error.