### PR TITLE
fix warning text for bad sxHeight

### DIFF
--- a/src/os2.cc
+++ b/src/os2.cc
@@ -209,7 +209,7 @@ bool OpenTypeOS2::Parse(const uint8_t *data, size_t length) {
   }
 
   if (this->table.x_height < 0) {
-    Warning("Bad sxHeight settig it to 0: %d", this->table.x_height);
+    Warning("Bad sxHeight setting it to 0: %d", this->table.x_height);
     this->table.x_height = 0;
   }
   if (this->table.cap_height < 0) {


### PR DESCRIPTION
Fixes a warning message for a bad sxHeight. 

Issue reported here: https://bugzilla.mozilla.org/show_bug.cgi?id=1937231

Reproducing the issue from the above thread:
<img width="413" alt="image" src="https://github.com/user-attachments/assets/6586fbdb-c20f-40df-b2ad-dacf227832e1" />
