### PR TITLE
Introduce new TABLE_ACTION_SANITIZE_SOFT action.

### DIFF
--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -172,7 +172,9 @@ enum TableAction {
   TABLE_ACTION_DEFAULT,  // Use OTS's default action for that table
   TABLE_ACTION_SANITIZE, // Sanitize the table, potentially dropping it
   TABLE_ACTION_PASSTHRU, // Serialize the table unchanged
-  TABLE_ACTION_DROP      // Drop the table
+  TABLE_ACTION_DROP,     // Drop the table
+  TABLE_ACTION_SANITIZE_SOFT, // Sanitize the table, but without failing overall
+                              // sanitzation even if this table fails/is dropped
 };
 
 class OTSContext {

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -1045,6 +1045,12 @@ bool Font::ParseTable(const TableEntry& table_entry, const uint8_t* data,
       ret = table->Parse(table_data, table_length);
       if (ret)
         AddTable(table_entry, table);
+      else if (action == TABLE_ACTION_SANITIZE_SOFT) {
+        // We're dropping the table (having reported whatever errors we found),
+        // but do not return failure, so that processing continues.
+        delete table;
+        ret = true;
+      }
     }
   }
 


### PR DESCRIPTION
This action (not used as the default for any table tags) performs the same table-specific Parse() as TABLE_ACTION_SANITIZE, but if parsing fails, it will drop the table but _not_ return a failure status to the overall processing.

This can be used by a client that wishes to continue processing and using a resource even if certain tables may fail sanitization and be discarded.

It differs from SANITIZE in that failure to parse does not completely stop processing of the resource and return an overall failure.

It differs from PASS_THRU in that the table is subject to sanitization, reporting any errors found, and will be dropped if it fails, rather than silently accepted.

It differs from DROP in that the table is only dropped if (unrecoverable) errors are found by Parse(); if the table is valid, it will be retained.