### PR TITLE
New overload OTSContext::Process to lower memory use processing WOFF2

### DIFF
--- a/include/opentype-sanitiser.h
+++ b/include/opentype-sanitiser.h
@@ -34,6 +34,7 @@ typedef unsigned __int64 uint64_t;
 #include <cassert>
 #include <cstddef>
 #include <cstring>
+#include <limits>
 
 #define OTS_TAG(c1,c2,c3,c4) ((uint32_t)((((uint8_t)(c1))<<24)|(((uint8_t)(c2))<<16)|(((uint8_t)(c3))<<8)|((uint8_t)(c4))))
 #define OTS_UNTAG(tag)       ((char)((tag)>>24)), ((char)((tag)>>16)), ((char)((tag)>>8)), ((char)(tag))
@@ -162,6 +163,95 @@ class OTSStream {
   uint32_t chksum_;
 };
 
+class ExpandingMemoryStream : public OTSStream {
+ public:
+  ExpandingMemoryStream() {}
+
+  ExpandingMemoryStream(size_t initial, size_t limit)
+      : length_(initial), limit_(limit), off_(0) {
+    ptr_ = new uint8_t[length_];
+  }
+
+  ~ExpandingMemoryStream() {
+    if (ptr_) {
+      delete[] static_cast<uint8_t*>(ptr_);
+    }
+  }
+
+  ExpandingMemoryStream(const ExpandingMemoryStream&) = delete;
+  ExpandingMemoryStream& operator=(const ExpandingMemoryStream& other) = delete;
+
+  ExpandingMemoryStream(ExpandingMemoryStream&& other) {
+    *this = std::move(other);
+  }
+
+  ExpandingMemoryStream& operator=(ExpandingMemoryStream&& other) {
+    if (ptr_) {
+      delete[] static_cast<uint8_t*>(ptr_);
+    }
+
+    this->ptr_ = other.ptr_;
+    this->length_ = other.length_;
+    this->limit_ = other.limit_;
+    this->off_ = other.off_;
+
+    other.ptr_ = nullptr;
+    other.length_ = 0u;
+    other.limit_ = 0u;
+    other.off_ = 0u;
+    return *this;
+  }
+
+  operator bool() const { return ptr_ != nullptr; }
+
+  const uint8_t* data() { return static_cast<uint8_t*>(ptr_); }
+
+  void* get() const {
+    return ptr_;
+  }
+
+  size_t size() override { return limit_; }
+
+  bool WriteRaw(const void *data, size_t length) override {
+    if ((off_ + length > length_) ||
+        (length > std::numeric_limits<size_t>::max() - off_)) {
+      if (length_ == limit_)
+        return false;
+      size_t new_length = (length_ + 1) * 2;
+      if (new_length < length_)
+        return false;
+      if (new_length > limit_)
+        new_length = limit_;
+      uint8_t* new_buf = new uint8_t[new_length];
+      std::memcpy(new_buf, ptr_, length_);
+      length_ = new_length;
+      delete[] static_cast<uint8_t*>(ptr_);
+      ptr_ = new_buf;
+      return WriteRaw(data, length);
+    }
+    std::memcpy(static_cast<char*>(ptr_) + off_, data, length);
+    off_ += static_cast<off_t>(length);
+    return true;
+  }
+
+  bool Seek(off_t position) override {
+    if (position < 0) return false;
+    if (static_cast<size_t>(position) > length_) return false;
+    off_ = position;
+    return true;
+  }
+
+  off_t Tell() const override {
+    return off_;
+  }
+
+ private:
+  void* ptr_ = nullptr;
+  size_t length_ = 0;
+  size_t limit_ = 0;
+  off_t off_ = 0;
+};
+
 #ifdef __GCC__
 #define MSGFUNC_FMT_ATTR __attribute__((format(printf, 2, 3)))
 #else
@@ -192,6 +282,21 @@ class OTSContext {
     //     the corresponding font will be returned, otherwise the whole
     //     collection. Ignored for non-collection fonts.
     bool Process(OTSStream *output, const uint8_t *input, size_t length, uint32_t index = -1);
+
+    // Process a given OpenType file and write out a sanitized version
+    //   output: a pointer to an object implementing the OTSStream interface. The
+    //     sanitisied output will be written to this. In the even of a failure,
+    //     partial output may have been written.
+    //   input: the OpenType file as ExpandingMemoryStream
+    //   index: if the input is a font collection and index is specified, then
+    //     the corresponding font will be returned, otherwise the whole
+    //     collection. Ignored for non-collection fonts.
+    //   return value: ots::ExpandingMemoryStream containing the sanitized
+    //   version as value if processing succeeded. Default-constructed
+    //   ots::ExpandingMemoryStream is returned on failure.
+    ots::ExpandingMemoryStream Process(
+        ots::ExpandingMemoryStream&& input,
+        uint32_t index = -1);
 
     // This function will be called when OTS is reporting an error.
     //   level: the severity of the generated message:

--- a/include/ots-memory-stream.h
+++ b/include/ots-memory-stream.h
@@ -47,63 +47,6 @@ class MemoryStream : public OTSStream {
   off_t off_;
 };
 
-class ExpandingMemoryStream : public OTSStream {
- public:
-  ExpandingMemoryStream(size_t initial, size_t limit)
-      : length_(initial), limit_(limit), off_(0) {
-    ptr_ = new uint8_t[length_];
-  }
-
-  ~ExpandingMemoryStream() {
-    delete[] static_cast<uint8_t*>(ptr_);
-  }
-
-  void* get() const {
-    return ptr_;
-  }
-
-  size_t size() override { return limit_; }
-
-  bool WriteRaw(const void *data, size_t length) override {
-    if ((off_ + length > length_) ||
-        (length > std::numeric_limits<size_t>::max() - off_)) {
-      if (length_ == limit_)
-        return false;
-      size_t new_length = (length_ + 1) * 2;
-      if (new_length < length_)
-        return false;
-      if (new_length > limit_)
-        new_length = limit_;
-      uint8_t* new_buf = new uint8_t[new_length];
-      std::memcpy(new_buf, ptr_, length_);
-      length_ = new_length;
-      delete[] static_cast<uint8_t*>(ptr_);
-      ptr_ = new_buf;
-      return WriteRaw(data, length);
-    }
-    std::memcpy(static_cast<char*>(ptr_) + off_, data, length);
-    off_ += static_cast<off_t>(length);
-    return true;
-  }
-
-  bool Seek(off_t position) override {
-    if (position < 0) return false;
-    if (static_cast<size_t>(position) > length_) return false;
-    off_ = position;
-    return true;
-  }
-
-  off_t Tell() const override {
-    return off_;
-  }
-
- private:
-  void* ptr_;
-  size_t length_;
-  const size_t limit_;
-  off_t off_;
-};
-
 }  // namespace ots
 
 #endif  // OTS_MEMORY_STREAM_H_

--- a/src/ots.cc
+++ b/src/ots.cc
@@ -525,44 +525,63 @@ bool ProcessWOFF(ots::FontFile *header,
   return ProcessGeneric(header, font, woff_tag, output, data, length, tables, file);
 }
 
-bool ProcessWOFF2(ots::FontFile *header,
-                  ots::OTSStream *output,
-                  const uint8_t *data,
-                  size_t length,
-                  uint32_t index) {
-  size_t decompressed_size = woff2::ComputeWOFF2FinalSize(data, length);
+ots::ExpandingMemoryStream ProcessWOFF2(
+    ots::FontFile* header,
+    ots::ExpandingMemoryStream&& input_output,
+    size_t length,
+    uint32_t index) {
+  size_t decompressed_size =
+      woff2::ComputeWOFF2FinalSize(input_output.data(), length);
 
   if (decompressed_size < length) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 is less than compressed size");
+    OTS_FAILURE_MSG_HDR(
+        "Size of decompressed WOFF 2.0 is less than compressed size");
+    return ots::ExpandingMemoryStream();
   }
 
   if (decompressed_size == 0) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 is set to 0");
+    OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 is set to 0");
+    return ots::ExpandingMemoryStream();
   }
   // decompressed font must be <= OTS_MAX_DECOMPRESSED_FILE_SIZE
   if (decompressed_size > OTS_MAX_DECOMPRESSED_FILE_SIZE) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds %gMB",
-                               OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));
+    OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds %gMB",
+                        OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));
+    return ots::ExpandingMemoryStream();
   }
 
-  if (decompressed_size > output->size()) {
-    return OTS_FAILURE_MSG_HDR("Size of decompressed WOFF 2.0 font exceeds output size (%gMB)", output->size() / (1024.0 * 1024.0));
+  if (decompressed_size > input_output.size()) {
+    OTS_FAILURE_MSG_HDR(
+        "Size of decompressed WOFF 2.0 font exceeds output size (%gMB)",
+        input_output.size() / (1024.0 * 1024.0));
+    return ots::ExpandingMemoryStream();
   }
 
   std::string buf(decompressed_size, 0);
   woff2::WOFF2StringOut out(&buf);
   out.SetMaxSize(decompressed_size);
-  if (!woff2::ConvertWOFF2ToTTF(data, length, &out)) {
-    return OTS_FAILURE_MSG_HDR("Failed to convert WOFF 2.0 font to SFNT");
+  if (!woff2::ConvertWOFF2ToTTF(input_output.data(), length, &out)) {
+    OTS_FAILURE_MSG_HDR("Failed to convert WOFF 2.0 font to SFNT");
+    return ots::ExpandingMemoryStream();
   }
   const uint8_t *decompressed = reinterpret_cast<const uint8_t*>(buf.data());
 
-  if (data[4] == 't' && data[5] == 't' && data[6] == 'c' && data[7] == 'f') {
-    return ProcessTTC(header, output, decompressed, out.Size(), index);
+  bool result;
+  // Important to seek to 0 so we write from start of buffer
+  input_output.Seek(0u);
+
+  if (input_output.data()[4] == 't' && input_output.data()[5] == 't' &&
+      input_output.data()[6] == 'c' && input_output.data()[7] == 'f') {
+    result = ProcessTTC(header, &input_output, decompressed, out.Size(), index);
   } else {
     ots::Font font(header);
-    return ProcessTTF(header, &font, output, decompressed, out.Size());
+    result = ProcessTTF(header, &font, &input_output, decompressed, out.Size());
   }
+
+  if (result) {
+    return std::move(input_output);
+  }
+  return ots::ExpandingMemoryStream();
 }
 
 ots::TableAction GetTableAction(const ots::FontFile *header, uint32_t tag) {
@@ -665,7 +684,7 @@ bool ProcessGeneric(ots::FontFile *header,
       if (tables[i].uncompressed_length > OTS_MAX_DECOMPRESSED_TABLE_SIZE) {
         return OTS_FAILURE_MSG_HDR("%c%c%c%c: decompressed table length exceeds %gMB",
                                    OTS_UNTAG(tables[i].tag),
-                                   OTS_MAX_DECOMPRESSED_TABLE_SIZE / (1024.0 * 1024.0));        
+                                   OTS_MAX_DECOMPRESSED_TABLE_SIZE / (1024.0 * 1024.0));
       }
       if (uncompressed_sum + tables[i].uncompressed_length < uncompressed_sum) {
         return OTS_FAILURE_MSG_TAG("overflow of decompressed sum", tables[i].tag);
@@ -688,7 +707,7 @@ bool ProcessGeneric(ots::FontFile *header,
   // All decompressed tables decompressed must be <= OTS_MAX_DECOMPRESSED_FILE_SIZE.
   if (uncompressed_sum > OTS_MAX_DECOMPRESSED_FILE_SIZE) {
     return OTS_FAILURE_MSG_HDR("decompressed sum exceeds %gMB",
-                               OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));        
+                               OTS_MAX_DECOMPRESSED_FILE_SIZE / (1024.0 * 1024.0));
   }
 
   if (uncompressed_sum > output->size()) {
@@ -1180,30 +1199,58 @@ bool TablePassthru::Serialize(OTSStream *out) {
   return true;
 }
 
-bool OTSContext::Process(OTSStream *output,
-                         const uint8_t *data,
-                         size_t length,
-                         uint32_t index) {
+ots::ExpandingMemoryStream OTSContext::Process(
+    ots::ExpandingMemoryStream&& input_output,
+    uint32_t index) {
   FontFile header;
   Font font(&header);
   header.context = this;
 
-  if (length < 4) {
-    return OTS_FAILURE_MSG_(&header, "file less than 4 bytes");
+  if (input_output.Tell() < 4) {
+    OTS_FAILURE_MSG_(&header, "file less than 4 bytes");
+    return ots::ExpandingMemoryStream();
+  }
+
+  // Special-case WOFF2 as we see it using a lot of RAM for some fonts.
+  if (input_output.data()[0] == 'w' && input_output.data()[1] == 'O' &&
+      input_output.data()[2] == 'F' && input_output.data()[3] == '2') {
+    return ProcessWOFF2(&header, std::move(input_output), input_output.Tell(),
+                        index);
   }
 
   bool result;
-  if (data[0] == 'w' && data[1] == 'O' && data[2] == 'F' && data[3] == 'F') {
-    result = ProcessWOFF(&header, &font, output, data, length);
-  } else if (data[0] == 'w' && data[1] == 'O' && data[2] == 'F' && data[3] == '2') {
-    result = ProcessWOFF2(&header, output, data, length, index);
-  } else if (data[0] == 't' && data[1] == 't' && data[2] == 'c' && data[3] == 'f') {
-    result = ProcessTTC(&header, output, data, length, index);
+  ots::ExpandingMemoryStream output(input_output.Tell(), input_output.size());
+  if (input_output.data()[0] == 'w' && input_output.data()[1] == 'O' &&
+      input_output.data()[2] == 'F' && input_output.data()[3] == 'F') {
+    result = ProcessWOFF(&header, &font, &output, input_output.data(),
+                         input_output.Tell());
+  } else if (input_output.data()[0] == 't' && input_output.data()[1] == 't' &&
+             input_output.data()[2] == 'c' && input_output.data()[3] == 'f') {
+    result = ProcessTTC(&header, &output, input_output.data(),
+                        input_output.Tell(), index);
   } else {
-    result = ProcessTTF(&header, &font, output, data, length);
+    result = ProcessTTF(&header, &font, &output, input_output.data(),
+                        input_output.Tell());
   }
 
-  return result;
+  if (result) {
+    return output;
+  }
+  return ots::ExpandingMemoryStream();
+}
+
+bool OTSContext::Process(OTSStream* output,
+                         const uint8_t* data,
+                         size_t length,
+                         uint32_t index) {
+  ots::ExpandingMemoryStream input(length, output->size());
+  input.WriteRaw(data, length);
+  ots::ExpandingMemoryStream out = Process(std::move(input), index);
+  if (!out) {
+    return false;
+  }
+  *output = std::move(out);
+  return true;
 }
 
 }  // namespace ots


### PR DESCRIPTION
NOTE: This patch is intrusive. It's not necessarily expected that this patch can land in its current state, rather it is provided to spur discussion.

We are Chromium integrators and we've seen that processing some WOFF2 fonts can take up a lot of memory. This patch adds a new overload to OTSContext::Process in order to make it possible to use less memory while processing WOFF2 fonts. It does so via the following changes:

- Makes ots::ExpandingMemoryStream part of public ots API.
- Makes ots::ExpandingMemoryStream handle move-construct and move-assignment.
- Adds an overload of ots::OTSContext::Process that takes an rvalue ref to ots::ExpandingMemoryStream as input buffer.
- Makes ots::OTSContext::Process return the output buffer instead of writing to a separate output buffer.

Resolves #298