### PR TITLE
[cff] Validate ordering of hint operators in charstring.

### DIFF
--- a/src/cff_charstring.cc
+++ b/src/cff_charstring.cc
@@ -405,6 +405,16 @@ bool ExecuteCharStringOperator(ots::OpenTypeCFF& cff,
     if (stack_size < 2) {
       return OTS_FAILURE();
     }
+    if (op == ots::kHStem || op == ots::kHStemHm) {
+      if (cs_ctx.hint_state > ots::kHs) {
+        return OTS_FAILURE();
+      }
+    } else {
+      if (cs_ctx.hint_state > ots::kVs) {
+        return OTS_FAILURE();
+      }
+      cs_ctx.hint_state = ots::kVs;
+    }
     if ((stack_size % 2) == 0) {
       successful = true;
     } else if ((!(cs_ctx.width_seen)) && (((stack_size - 1) % 2) == 0)) {
@@ -432,6 +442,7 @@ bool ExecuteCharStringOperator(ots::OpenTypeCFF& cff,
     while (!argument_stack->empty())
       argument_stack->pop();
     cs_ctx.width_seen = true;
+    cs_ctx.hint_state = ots::kHm;
     return successful ? true : OTS_FAILURE();
   }
 
@@ -446,6 +457,7 @@ bool ExecuteCharStringOperator(ots::OpenTypeCFF& cff,
     while (!argument_stack->empty())
       argument_stack->pop();
     cs_ctx.width_seen = true;
+    cs_ctx.hint_state = ots::kHm;
     return successful ? true : OTS_FAILURE();
   }
 
@@ -470,7 +482,14 @@ bool ExecuteCharStringOperator(ots::OpenTypeCFF& cff,
     if (!successful) {
        return OTS_FAILURE();
     }
-
+    if (op == ots::kHintMask) {
+      cs_ctx.hint_state = ots::kHm;
+    } else {
+      if (cs_ctx.hint_state > ots::kCm) {
+        return OTS_FAILURE();
+      }
+      cs_ctx.hint_state = ots::kCm;
+    }
     if ((cs_ctx.num_stems) == 0) {
       return OTS_FAILURE();
     }

--- a/src/cff_charstring.h
+++ b/src/cff_charstring.h
@@ -95,10 +95,20 @@ enum CharStringOperator {
   // Operators that are undocumented will be rejected.
 };
 
+// Which hint operator we're up to in the required ordering
+// (https://adobe-type-tools.github.io/font-tech-notes/pdfs/5177.Type2.pdf#G3.31003)
+enum HintState {
+  kHs,
+  kVs,
+  kCm,
+  kHm,
+};
+
 struct CharStringContext {
   bool endchar_seen = false;
   bool width_seen = false;
   size_t num_stems = 0;
+  HintState hint_state = kHs;
   bool cff2 = false;
   bool blend_seen = false;
   bool vsindex_seen = false;

--- a/tests/cff_charstring_test.cc
+++ b/tests/cff_charstring_test.cc
@@ -966,6 +966,49 @@ TEST(ValidateTest, TestHintMask) {
   }
 }
 
+TEST(ValidateTest, TestStemOrder) {
+  {
+    const int char_string[] = {
+      1, 2, kOpPrefix, ots::kHStemHm,
+      3, 4, kOpPrefix, ots::kVStemHm,
+      kOpPrefix, ots::kHintMask, 0x00,
+      kOpPrefix, ots::kEndChar,
+    };
+    EXPECT_TRUE(ValidateCharStrings(char_string, ARRAYSIZE(char_string)));
+  }
+  {
+    const int char_string[] = {
+      1, 2, kOpPrefix, ots::kVStem,
+      3, 4, kOpPrefix, ots::kHStem,  // stems must be in canonical order
+      kOpPrefix, ots::kHintMask, 0x00,
+      kOpPrefix, ots::kEndChar,
+    };
+    EXPECT_FALSE(ValidateCharStrings(char_string, ARRAYSIZE(char_string)));
+  }
+}
+
+TEST(ValidateTest, TestStemsFirst) {
+  {
+    const int char_string[] = {
+      1, 2, kOpPrefix, ots::kHStemHm,
+      kOpPrefix, ots::kHintMask, 0x00,
+      3, 4, kOpPrefix, ots::kHStemHm,  // stems must be declared at the beginning
+      kOpPrefix, ots::kHintMask, 0x00,
+      kOpPrefix, ots::kEndChar,
+    };
+    EXPECT_FALSE(ValidateCharStrings(char_string, ARRAYSIZE(char_string)));
+  }
+  {
+    const int char_string[] = {
+      1, kOpPrefix, ots::kVMoveTo,
+      1, 2, kOpPrefix, ots::kHStemHm,  // stems must be declared at the beginning
+      kOpPrefix, ots::kHintMask, 0x00,
+      kOpPrefix, ots::kEndChar,
+    };
+    EXPECT_FALSE(ValidateCharStrings(char_string, ARRAYSIZE(char_string)));
+  }
+}
+
 TEST(ValidateTest, TestCntrMask) {
   {
     const int char_string[] = {


### PR DESCRIPTION
The spec requires that all stems are defined at the beginning of the charstring (before any contours), and that the hint ops are used in a specific order (HSTEMs before VSTEMs; CNTRMASK before HINTMASK).

https://adobe-type-tools.github.io/font-tech-notes/pdfs/5177.Type2.pdf#G3.31003

NB: We don't currently enforce the spec requirement that if HINTMASK is present in the charstring, the stems must be defined using the ...HM variants of HSTEM and VSTEM operators.