### PR TITLE
[cff] Reject BCD number with excessively large exponent.

### DIFF
--- a/src/cff.cc
+++ b/src/cff.cc
@@ -289,6 +289,9 @@ bool ParseDictDataBcd(ots::Buffer &table, std::vector<Operand> &operands) {
       }
       if (read_e) {
         exponent = exponent * 10 + nibbles[i];
+        if (exponent >= 120) {
+          return OTS_FAILURE();  // exponent excessively large.
+        }
         continue;
       }
       if (dec_value < 1.0f) {


### PR DESCRIPTION
There's no reasonable use-case for BCD-encoded numbers with huge exponents (over 100, say) in CFF; let's just reject anything that's going to approach the limit of what float32 can represent anyhow.