### PR TITLE
Update googletest wrap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.10'
 
     - name: Install Python Dependencies
-      run: pip install --upgrade meson==0.60.2 ninja
+      run: pip install --upgrade meson==1.11.1 ninja
 
     - name: MSVC Setup
       if: matrix.os == 'windows-latest'

--- a/meson.build
+++ b/meson.build
@@ -265,6 +265,7 @@ cff_charstring = executable('cff_charstring',
   include_directories: include_directories(['include', 'src']),
   link_with: libots,
   dependencies: gtest,
+  override_options: ['cpp_std=c++17'],
 )
 
 test('cff_charstring', cff_charstring)
@@ -275,6 +276,7 @@ passthru_test = executable('passthru_test',
   include_directories: include_directories(['include']),
   link_with: libots,
   dependencies: gtest,
+  override_options: ['cpp_std=c++17'],
 )
 
 test('passthru_test', passthru_test,

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,15 +1,16 @@
 [wrap-file]
-directory = googletest-release-1.11.0
-source_url = https://github.com/google/googletest/archive/release-1.11.0.tar.gz
-source_filename = gtest-1.11.0.tar.gz
-source_hash = b4870bf121ff7795ba20d20bcdd8627b8e088f2d1dab299a031c1034eddc93d5
-patch_filename = gtest_1.11.0-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.11.0-2/get_patch
-patch_hash = 764530d812ac161c9eab02a8cfaec67c871fcfc5548e29fd3d488070913d4e94
+directory = googletest-1.17.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz
+source_filename = googletest-1.17.0.tar.gz
+source_hash = 65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
+patch_filename = gtest_1.17.0-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.17.0-4/get_patch
+patch_hash = 3abf7662d09db706453a5b064a1e914678c74b9d9b0b19382747ca561d0d8750
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.17.0-4/googletest-1.17.0.tar.gz
+wrapdb_version = 1.17.0-4
 
 [provide]
 gtest = gtest_dep
 gtest_main = gtest_main_dep
 gmock = gmock_dep
 gmock_main = gmock_main_dep
-


### PR DESCRIPTION
The tests that use it now build with C++17 as upstream requires it now.

* Fixes https://github.com/khaledhosny/ots/issues/301