### PR TITLE
[layout] Don’t check substitution/context length against numGlyphs

### DIFF
--- a/src/gsub.cc
+++ b/src/gsub.cc
@@ -38,9 +38,6 @@ bool ParseSequenceTable(const ots::Font *font,
   if (!subtable.ReadU16(&glyph_count)) {
     return OTS_FAILURE_MSG("Failed to read glyph count in sequence table");
   }
-  if (glyph_count > num_glyphs) {
-    return OTS_FAILURE_MSG("bad glyph count %d > %d", glyph_count, num_glyphs);
-  }
   for (unsigned i = 0; i < glyph_count; ++i) {
     uint16_t substitute = 0;
     if (!subtable.ReadU16(&substitute)) {
@@ -62,9 +59,6 @@ bool ParseAlternateSetTable(const ots::Font *font,
   uint16_t glyph_count = 0;
   if (!subtable.ReadU16(&glyph_count)) {
     return OTS_FAILURE_MSG("Failed to read alternate set header");
-  }
-  if (glyph_count > num_glyphs) {
-    return OTS_FAILURE_MSG("Bad glyph count %d > %d in alternate set table", glyph_count, num_glyphs);
   }
   for (unsigned i = 0; i < glyph_count; ++i) {
     uint16_t alternate = 0;

--- a/src/layout.cc
+++ b/src/layout.cc
@@ -489,8 +489,8 @@ bool ParseClassRuleTable(const ots::Font *font,
     return OTS_FAILURE_MSG("Failed to read header of class rule table");
   }
 
-  if (glyph_count == 0 || glyph_count >= num_glyphs) {
-    return OTS_FAILURE_MSG("Bad glyph count %d in class rule table", glyph_count);
+  if (glyph_count == 0) {
+    return OTS_FAILURE_MSG("Glyph count cannot be 0 in class rule table");
   }
 
   // ClassRule table contains an array of classes. Each value of classes
@@ -614,9 +614,6 @@ bool ParseContextFormat3(const ots::Font *font,
     return OTS_FAILURE_MSG("Failed to read header in context format 3");
   }
 
-  if (glyph_count >= num_glyphs) {
-    return OTS_FAILURE_MSG("Bad glyph count %d in context format 3", glyph_count);
-  }
   const unsigned lookup_record_end = 2 * static_cast<unsigned>(glyph_count) +
       4 * static_cast<unsigned>(lookup_count) + 6;
   if (lookup_record_end > std::numeric_limits<uint16_t>::max()) {


### PR DESCRIPTION
There is no relation whatsoever between the two.

* Fixes https://github.com/khaledhosny/ots/issues/304