### PR TITLE
[ots] Accept bitmap-only fonts with EBDT/EBLC

### DIFF
--- a/src/ots.cc
+++ b/src/ots.cc
@@ -807,8 +807,10 @@ bool ProcessGeneric(ots::FontFile *header,
       OTS_WARNING_MSG_HDR("fixing incorrect maxp version for CFF font");
       maxp->version_1 = false;
     }
-  } else if (font->GetTable(OTS_TAG('C','B','D','T')) &&
-             font->GetTable(OTS_TAG('C','B','L','C'))) {
+  } else if ((font->GetTable(OTS_TAG('C','B','D','T')) &&
+              font->GetTable(OTS_TAG('C','B','L','C'))) ||
+             (font->GetTable(OTS_TAG('E','B','D','T')) &&
+              font->GetTable(OTS_TAG('E','B','L','C')))) {
       // We don't sanitize bitmap tables, but don’t reject bitmap-only fonts if
       // we are asked to pass them thru.
   } else {


### PR DESCRIPTION
**Description**
**Context :** This is part of work to support bitmap-only fonts (CBDT/CBLC color bitmaps and EBDT/EBLC monochrome bitmaps) in Chromium. Chromium currently rejects such fonts at the OTS pass before they reach the font stack, so this change is a prerequisite for the wider effort.
 
Extend the existing bitmap-only pass-through (CBDT/CBLC) to also accept fonts whose only glyph data is the monochrome embedded bitmap pair EBDT/EBLC. Previously such fonts were rejected with "no supported glyph data table(s) present" even when the caller asked OTS to pass bitmap-only fonts through.